### PR TITLE
Fix tests on Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 
 python:
   - "2.7"
+  - "3.6"
 
 before_install:
   - pushd ..

--- a/src/fmu/ensemble/ensemble.py
+++ b/src/fmu/ensemble/ensemble.py
@@ -13,6 +13,7 @@ import six
 
 from datetime import datetime, date, time
 import pandas as pd
+import numpy as np
 from ecl import EclDataType
 from ecl.eclfile import EclKW
 
@@ -525,7 +526,7 @@ class ScratchEnsemble(object):
                 data = realization.get_df(localpath)
                 if isinstance(data, dict):
                     data = pd.DataFrame(index=[1], data=data)
-                elif isinstance(data, (str, int, float)):
+                elif isinstance(data, (str, int, float, np.integer, np.floating)):
                     data = pd.DataFrame(index=[1], columns=[localpath], data=data)
                 if isinstance(data, pd.DataFrame):
                     dflist[index] = data

--- a/src/fmu/ensemble/ensembleset.py
+++ b/src/fmu/ensemble/ensembleset.py
@@ -478,7 +478,7 @@ class EnsembleSet(object):
 
         CODE DUPLICATION from realization.py
         """
-        basenames = map(os.path.basename, self.keys())
+        basenames = [os.path.basename(key) for key in self.keys()]
         if basenames.count(shortpath) == 1:
             short2path = {os.path.basename(x): x for x in self.keys()}
             return short2path[shortpath]

--- a/src/fmu/ensemble/ensembleset.py
+++ b/src/fmu/ensemble/ensembleset.py
@@ -147,7 +147,7 @@ class EnsembleSet(object):
         """
         Return a list of named ensembles in this set
         """
-        return self._ensembles.keys()
+        return list(self._ensembles.keys())
 
     def keys(self):
         """

--- a/src/fmu/ensemble/observations.py
+++ b/src/fmu/ensemble/observations.py
@@ -371,7 +371,7 @@ class Observations(object):
         supported_categories = ["smry", "smryh", "txt", "scalar", "rft"]
 
         # Check top level keys in observations dict:
-        for key in self.observations.keys():
+        for key in list(self.observations):
             if key not in supported_categories:
                 self.observations.pop(key)
                 logger.error("Observation category %s not supported", key)

--- a/src/fmu/ensemble/virtualrealization.py
+++ b/src/fmu/ensemble/virtualrealization.py
@@ -8,6 +8,7 @@ import os
 import fnmatch
 import shutil
 import pandas as pd
+import numpy as np
 
 from .etc import Interaction
 
@@ -242,9 +243,7 @@ class VirtualRealization(object):
             return data
         elif isinstance(data, pd.Series):
             return data.to_dict()
-        elif isinstance(data, dict):
-            return data
-        elif isinstance(data, str) or isinstance(data, int) or isinstance(data, float):
+        elif isinstance(data, (str, dict, int, float, np.integer, np.floating)):
             return data
         else:
             raise ValueError("BUG: Unknown datatype")

--- a/src/fmu/ensemble/virtualrealization.py
+++ b/src/fmu/ensemble/virtualrealization.py
@@ -111,11 +111,7 @@ class VirtualRealization(object):
                 with open(filename, "w") as fhandle:
                     for paramkey in data.keys():
                         fhandle.write(paramkey + " " + str(data[paramkey]) + "\n")
-            elif (
-                isinstance(data, str)
-                or isinstance(data, float)
-                or isinstance(data, int)
-            ):
+            elif isinstance(data, (str, float, int, np.integer, np.floating)):
                 with open(filename, "w") as fhandle:
                     fhandle.write(str(data))
             else:
@@ -160,19 +156,15 @@ class VirtualRealization(object):
                 else:
                     # GUESS scalar, key-value txt or CSV from the first
                     # two lines. SHAKY!
-                    commafields = 0
-                    spacefields = 0
-                    linecount = 0
                     with open(os.path.join(root, filename)) as realfile:
-                        line1 = realfile.next()
-                        commafields = len(line1.split(","))
-                        spacefields = len(line1.split())
-                        try:
-                            realfile.next()
-                            linecount = 2
-                        except StopIteration:
-                            linecount = 1
+                        lines = realfile.readlines()
+
+                    linecount = len(lines)
+                    commafields = len(lines[0].split(","))
+                    spacefields = len(lines[0].split())
+          
                     print(filename, commafields, spacefields, linecount)
+                    
                     if spacefields == 2 and commafields == 1:
                         # key-value txt file!
                         self.append(

--- a/src/fmu/ensemble/virtualrealization.py
+++ b/src/fmu/ensemble/virtualrealization.py
@@ -164,7 +164,6 @@ class VirtualRealization(object):
                     spacefields = len(lines[0].split())
           
                     print(filename, commafields, spacefields, linecount)
-                    
                     if spacefields == 2 and commafields == 1:
                         # key-value txt file!
                         self.append(

--- a/tests/test_observations.py
+++ b/tests/test_observations.py
@@ -10,6 +10,7 @@ import glob
 import datetime
 import yaml
 import pandas as pd
+import numpy as np
 import six
 import pytest
 
@@ -116,7 +117,7 @@ def test_real_mismatch():
     # and yield the same result
     obs2r = Observations(yaml.full_load(obs2.to_yaml()))
     realmis2r = obs2r.mismatch(real)
-    assert (realmis2["MISMATCH"].values == realmis2r["MISMATCH"].values).all()
+    assert np.all(realmis2["MISMATCH"].values.sort() == realmis2r["MISMATCH"].values.sort())
 
     # Test use of allocated values:
     obs3 = Observations({"smryh": [{"key": "FOPT", "histvec": "FOPTH"}]})

--- a/tests/test_realization.py
+++ b/tests/test_realization.py
@@ -103,7 +103,7 @@ def test_single_realization():
     real.load_scalar("npv.txt")
     assert real.get_df("npv.txt") == 3444
     assert real["npv.txt"] == 3444
-    assert isinstance(real.data["npv.txt"], int)
+    assert isinstance(real.data["npv.txt"], (int, np.integer))
     assert "npv.txt" in real.files.LOCALPATH.values
     assert real.files[real.files.LOCALPATH == "npv.txt"]["FILETYPE"].values[0] == "txt"
 

--- a/tests/test_virtualrealization.py
+++ b/tests/test_virtualrealization.py
@@ -175,9 +175,6 @@ def test_get_smry():
     )
     before_and_after = [datetime.date(1900, 1, 1), datetime.date(2100, 1, 1)]
 
-    print(vreal.get_smry(column_keys=["FOPR", "FOPT"], time_index=before_and_after))
-    print(real.get_smry(column_keys=["FOPR", "FOPT"], time_index=before_and_after))
-
     assert all(
         vreal.get_smry(column_keys=["FOPR", "FOPT"], time_index=before_and_after).sort_index(axis=1)
         == real.get_smry(column_keys=["FOPR", "FOPT"], time_index=before_and_after).sort_index(axis=1)

--- a/tests/test_virtualrealization.py
+++ b/tests/test_virtualrealization.py
@@ -174,9 +174,13 @@ def test_get_smry():
         vreal.get_smry(column_keys=["FOPR", "FOPT"], time_index=long_time_ago) == 0
     )
     before_and_after = [datetime.date(1900, 1, 1), datetime.date(2100, 1, 1)]
+
+    print(vreal.get_smry(column_keys=["FOPR", "FOPT"], time_index=before_and_after))
+    print(real.get_smry(column_keys=["FOPR", "FOPT"], time_index=before_and_after))
+
     assert all(
-        vreal.get_smry(column_keys=["FOPR", "FOPT"], time_index=before_and_after)
-        == real.get_smry(column_keys=["FOPR", "FOPT"], time_index=before_and_after)
+        vreal.get_smry(column_keys=["FOPR", "FOPT"], time_index=before_and_after).sort_index(axis=1)
+        == real.get_smry(column_keys=["FOPR", "FOPT"], time_index=before_and_after).sort_index(axis=1)
     )
 
     # If you supply repeating timeindices, you get duplicates out


### PR DESCRIPTION
Resolves #24 and resolves #20.

Fix various issues with the current tests on Python3:
- `pandas` returns a type of `np.integer` for `npv.txt` on Python3. Add `np.integer` and `np.floating` to the "allowed" instances. This could probably also happen on some Python2 environments.
- `map` returns list on Python2 and iterator on Python3. Use list comprehension instead (which could be argued to also be more pythonic).
- `dict.keys()` returns list on Python3 and `dict_keys` object on `Python3`.
- Check for equality on unsorted mismatch dataframes as long as the input are from dictionaries is non-defined for Python < 3.6. Change test to check for equality on sorted mismatches.
- Check for equality on unsorted dataframes where column names have been built from `set()` is non-deterministic. Change test to sort on column names (= summary vector name) before checking for equality