### PR TITLE
Remove watchdog and oyaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 pyyaml>=5.1
 oyaml
 wheel>=0.29.0
-watchdog>=0.8.3
 pylint
 pandas>0.23.0
 six>=1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pyyaml>=5.1
-oyaml
 wheel>=0.29.0
 pylint
 pandas>0.23.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,6 @@ oyaml
 pip>=18.0.0
 bumpversion>=0.5.3
 wheel>=0.29.0
-watchdog>=0.8.3
 flake8>=2.6.0
 tox>=2.3.1
 coverage>=4.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,4 @@
 pyyaml>=5.1
-oyaml
 pip>=18.0.0
 bumpversion>=0.5.3
 wheel>=0.29.0


### PR DESCRIPTION
Resolves #30.

In addition, removes `oyaml` as that also appears to [not be in use](https://github.com/equinor/fmu-ensemble/search?q=oyaml&unscoped_q=oyaml). 