### PR TITLE
Allow empty ensembleset name

### DIFF
--- a/src/fmu/ensemble/ensembleset.py
+++ b/src/fmu/ensemble/ensembleset.py
@@ -85,8 +85,9 @@ class EnsembleSet(object):
 
         # Check consistency in arguments.
         if not name:
-            logger.error("Name of EnsembleSet is required")
-            return
+            logger.warning("EnsembleSet name defaulted to 'ensembleset'")
+            name = "ensembleset"
+            self._name = name
         if name and not isinstance(name, str):
             logger.error("Name of EnsembleSet must be a string")
             return

--- a/tests/test_ensembleset.py
+++ b/tests/test_ensembleset.py
@@ -66,8 +66,14 @@ def test_ensembleset_reek001(tmp="TMP"):
         pass
     assert len(ensset) == 2  # Unchanged!
 
+    # Initializing nothing, we get warning about the missing name
+    noname = EnsembleSet()
+    assert noname.name  # not None
+    assert isinstance(noname.name, str)  # And it should be a string
+
     # Initialize starting from empty ensemble
     ensset2 = EnsembleSet("reek001", [])
+    assert ensset2.name == "reek001"
     ensset2.add_ensemble(iter0)
     ensset2.add_ensemble(iter1)
     assert len(ensset2) == 2
@@ -80,6 +86,7 @@ def test_ensembleset_reek001(tmp="TMP"):
 
     # Initialize directly from path with globbing:
     ensset3 = EnsembleSet("reek001direct", [])
+    assert ensset3.name == "reek001direct"
     ensset3.add_ensembles_frompath(ensdir)
     assert len(ensset3) == 2
 


### PR DESCRIPTION
This allows quick interactive stuff like `eset = EnsembleSet(frompath='.')`