### PR TITLE
Rmrc3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ python:
   - "2.7"
   - "3.6"
 
+addons:
+  apt:
+    packages:
+      - libsnappy-dev
+
 before_install:
   - pushd ..
   - export ROOT="$PWD"

--- a/docs/advancedusage.rst
+++ b/docs/advancedusage.rst
@@ -130,7 +130,7 @@ like:
     smryh:
       - key: FOPT
         histvec: FOPTH
-        time_index: monthly  # or yearly, daily, raw or last
+        time_index: monthly  # or yearly, daily, raw or last, or a ISO-date
 
 This file can be loaded in Python:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ numpy
 pandas>0.23.0
 six>=1.12.0
 pyarrow
-parquet
 xtgeo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 pyyaml>=5.1
 wheel>=0.29.0
 pylint
+numpy
 pandas>0.23.0
 six>=1.12.0
+pyarrow
+parquet

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pandas>0.23.0
 six>=1.12.0
 pyarrow
 parquet
+xtgeo

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,3 +14,5 @@ astroid
 pylint
 pandas>0.23.0
 six>=1.12.0
+parquet
+pyarrow

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -16,3 +16,4 @@ pandas>0.23.0
 six>=1.12.0
 parquet
 pyarrow
+xtgeo

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,6 +14,5 @@ astroid
 pylint
 pandas>0.23.0
 six>=1.12.0
-parquet
 pyarrow
 xtgeo

--- a/src/fmu/ensemble/ensemble.py
+++ b/src/fmu/ensemble/ensemble.py
@@ -339,15 +339,33 @@ class ScratchEnsemble(object):
         aggregated and stored as dataframes in the returned
         VirtualEnsemble
 
+        Unless specified, the VirtualEnsemble object wil
+        have the same 'name' as the ScratchEnsemble.
+
         Args:
             name (str): Name of the ensemble as virtualized.
         """
+        if not name:
+            name = self._name
         vens = VirtualEnsemble(name=name)
 
         for key in self.keys():
             vens.append(key, self.get_df(key))
         vens.update_realindices()
+
+        # __files is the magic name for the dataframe of
+        # loaded files.
+        vens.append("__files", self.files)
         return vens
+
+    def to_disk(self, filesystempath, delete=False, dumpcsv=True, dumpparquet=True):
+        """Dump ensemble data to a directory on disk.
+
+        The ScratchEnsemble is first converted to a VirtualEnsemble,
+        which is then dumped to disk. This function is a
+        convenience wrapper for to_disk() in VirtualEnsemble.
+        """
+        self.to_virtual().to_disk(filesystempath, delete, dumpcsv, dumpparquet)
 
     @property
     def parameters(self):

--- a/src/fmu/ensemble/ensemble.py
+++ b/src/fmu/ensemble/ensemble.py
@@ -347,6 +347,7 @@ class ScratchEnsemble(object):
         """
         if not name:
             name = self._name
+        logger.info("Creating virtual ensemble named %s", str(name))
         vens = VirtualEnsemble(name=name)
 
         for key in self.keys():

--- a/src/fmu/ensemble/realization.py
+++ b/src/fmu/ensemble/realization.py
@@ -384,6 +384,15 @@ class ScratchRealization(object):
                 else:
                     dtype = str
                 dframe = pd.read_csv(fullpath, dtype=dtype)
+                if "REAL" in dframe:
+                    dframe.rename(columns={"REAL": "REAL_ORIG"}, inplace=True)
+                    logger.warning(
+                        (
+                            "Loaded file %s already had the column REAL, "
+                            "this was renamed to REAL_ORIG"
+                        ),
+                        fullpath,
+                    )
             except pd.errors.EmptyDataError:
                 dframe = None  # or empty dataframe?
 

--- a/src/fmu/ensemble/realization.py
+++ b/src/fmu/ensemble/realization.py
@@ -405,6 +405,7 @@ class ScratchRealization(object):
             A dataframe with information from the STATUS files.
             Each row represents one job in one of the realizations.
         """
+
         statusfile = os.path.join(self._origpath, "STATUS")
         if not os.path.exists(statusfile):
             # This should not happen as long as __init__ requires STATUS
@@ -689,7 +690,7 @@ class ScratchRealization(object):
             columns=["FULLPATH", "FILETYPE", "LOCALPATH", "BASENAME"]
         )
         for searchpath in paths:
-            globs = glob.glob(os.path.join(self._origpath, searchpath))
+            globs = [f for f in glob.glob(os.path.join(self._origpath, searchpath)) if os.path.isfile(f)]
             for match in globs:
                 absmatch = os.path.abspath(match)
                 dirname = os.path.dirname(absmatch)

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -633,16 +633,16 @@ file is picked up"""
                 else:
                     logger.debug("from_disk: Ignoring file: %s", filename)
 
-            if not lazy_load:
-                # Load all found dataframes from disk:
-                for internalizedkey, filename in self.lazy_frames.iteritems():
-                    self._load_frame_fromdisk(internalizedkey, filename)
-                self.lazy_frames = {}
+        if not lazy_load:
+            # Load all found dataframes from disk:
+            for internalizedkey, filename in self.lazy_frames.iteritems():
+                self._load_frame_fromdisk(internalizedkey, filename)
+            self.lazy_frames = {}
 
-            # This function must be called whenever we have done
-            # something manually with the dataframes, like adding realizations.
-            # IT MIGHT BE INCORRECT IF LAZY_LOAD...
-            self.update_realindices()
+        # This function must be called whenever we have done
+        # something manually with the dataframes, like adding realizations.
+        # IT MIGHT BE INCORRECT IF LAZY_LOAD...
+        self.update_realindices()
 
     def _load_frame_fromdisk(self, key, filename):
         if filename.endswith(".parquet"):

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -53,6 +53,8 @@ class VirtualEnsemble(object):
                 "Can't initialize from both data and " + "disk at the same time"
             )
 
+        self.realindices = []
+
         # At ensemble level, this dictionary has dataframes only.
         # All dataframes have the column REAL.
         if data:
@@ -62,8 +64,6 @@ class VirtualEnsemble(object):
 
         if fromdisk:
             self.from_disk(fromdisk)
-
-        self.realindices = []
 
     def __len__(self):
         """Return the number of realizations (integer) included in the
@@ -634,6 +634,10 @@ file is picked up"""
                             self.data[internalizedkey] = parsedframe
                 else:
                     logger.debug("from_disk: Ignoring file: %s", filename)
+
+            # This function must be called whenever we have done
+            # something manually with the dataframes, like adding realizations.
+            self.update_realindices()
 
     def __repr__(self):
         """Textual representation of the object"""

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -595,6 +595,10 @@ file is picked up"""
         self._name = None
 
         for root, _, filenames in os.walk(filesystempath):
+            if "__discoveredfiles" in root:
+                # Never traverse the collections of dumped
+                # discovered files
+                continue
             localpath = root.replace(filesystempath, "")
             if localpath and localpath[0] == os.path.sep:
                 localpath = localpath[1:]

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -8,6 +8,8 @@ from __future__ import print_function
 import os
 import re
 import shutil
+import datetime
+
 import numpy as np
 import pandas as pd
 
@@ -583,6 +585,7 @@ file is picked up"""
             lazy_load (bool): If True, loading of dataframes from disk
                 will be postponed until get_df() is actually called.
         """
+        start_time = datetime.datetime.now()
         if fmt not in ["csv", "parquet"]:
             raise ValueError("Unknown format for from_disk: %s" % fmt)
 
@@ -649,6 +652,14 @@ file is picked up"""
         # something manually with the dataframes, like adding realizations.
         # IT MIGHT BE INCORRECT IF LAZY_LOAD...
         self.update_realindices()
+
+        end_time = datetime.datetime.now()
+        if lazy_load:
+            lazy_str = "(lazy) "
+        else:
+            lazy_str = ""
+        logger.info("Loading ensemble from disk %stook %g seconds", lazy_str, (end_time - start_time).total_seconds())
+
 
     def _load_frame_fromdisk(self, key, filename):
         if filename.endswith(".parquet"):
@@ -904,9 +915,8 @@ file is picked up"""
 
         Return:
             pd.Dataframe. Empty if no files are meaningful"""
-        if "__files" in self.data:
-            return self.data["__files"]
-        return pd.DataFrame()
+        files = self.get_df('__files')
+        return files
 
     @property
     def parameters(self):

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -104,7 +104,7 @@ class VirtualEnsemble(object):
         resemble the filenames from which they were originally
         loaded in a ScratchEnsemble.
         """
-        return self.data.keys() + self.lazy_frames.keys()
+        return list(self.data.keys()) + list(self.lazy_frames.keys())
 
     def lazy_keys(self):
         """Return keys that are not yet loaded, but will
@@ -702,7 +702,7 @@ file is picked up"""
             return self.data[localpath]
 
         # Allow shorthand, but check ambiguity
-        allkeys = self.data.keys() + self.lazy_frames.keys()
+        allkeys = list(self.data.keys()) + list(self.lazy_frames.keys())
         basenames = [os.path.basename(x) for x in allkeys]
         if basenames.count(localpath) == 1:
             shortcut2path = {os.path.basename(x): x for x in allkeys}

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -106,6 +106,12 @@ class VirtualEnsemble(object):
         """
         return self.data.keys() + self.lazy_frames.keys()
 
+    def lazy_keys(self):
+        """Return keys that are not yet loaded, but will
+        be loaded on demand"""
+        return list(self.lazy_frames.keys())
+
+
     def shortcut2path(self, shortpath):
         """
         Convert short pathnames to fully qualified pathnames

--- a/src/fmu/ensemble/virtualrealization.py
+++ b/src/fmu/ensemble/virtualrealization.py
@@ -76,6 +76,8 @@ class VirtualRealization(object):
             filesystempath : string with a directory, absolute or
                 relative. If it exists already, it must be empty,
                 otherwise we give up.
+            delete: boolean, if True, existing directory at the filesystempath
+                will be deleted before export.
         """
         if os.path.exists(filesystempath):
             if delete:

--- a/tests/test_realization.py
+++ b/tests/test_realization.py
@@ -139,6 +139,13 @@ def test_single_realization():
     # test basename and no extension:
     assert isinstance(real.get_df("simulator_volume_fipnum"), pd.DataFrame)
 
+    # Some CSV files might already contain the REAL column, this is not allowed
+    foo_df = pd.DataFrame(columns=["REAL", "FOOBAR"], data=[[0, 1], [2, 3]])
+    foo_df.to_csv(os.path.join(realdir, "foo-real.csv"), index=False)
+    real.load_csv("foo-real.csv")  # A warning will be issued.
+    assert "REAL" not in real.get_df("foo-real")
+    assert "FOOBAR" in real.get_df("foo-real")
+
     with pytest.raises(ValueError):
         real.get_df("notexisting.csv")
 

--- a/tests/test_rmrc.py
+++ b/tests/test_rmrc.py
@@ -55,7 +55,7 @@ def test_rmrc():
         "js_vens_dump", delete=True, dumpcsv=True, includefiles=True, symlinks=True
     )
     logger.info("Loading back from disk")
-    vens = VirtualEnsemble(fromdisk="js_vens_dump")
+    vens = VirtualEnsemble(fromdisk="js_vens_dump", lazy_load=True)
 
     logger.info("Doing asserts")
     assert not vens.files.empty

--- a/tests/test_rmrc.py
+++ b/tests/test_rmrc.py
@@ -38,7 +38,7 @@ def test_rmrc():
         "ens1", os.path.join(ens_path, "realization-*/{}".format(iteration_name))
     )
     logger.info("Loading smry")
-    # ens.load_smry(time_index="monthly")
+    ens.load_smry(time_index="yearly")
     logger.info("Finding *gri files")
     ens.find_files(
         "share/maps/depth/*.gri",

--- a/tests/test_rmrc.py
+++ b/tests/test_rmrc.py
@@ -6,10 +6,12 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import time
+import datetime
+
 import numpy as np
 import pandas as pd
 import pytest
-
 import xtgeo
 
 from fmu.ensemble import etc
@@ -55,7 +57,13 @@ def test_rmrc():
         "js_vens_dump", delete=True, dumpcsv=True, includefiles=True, symlinks=True
     )
     logger.info("Loading back from disk")
+    vens = VirtualEnsemble(fromdisk="js_vens_dump", lazy_load=False)
+    start_time = datetime.datetime.now()
     vens = VirtualEnsemble(fromdisk="js_vens_dump", lazy_load=True)
+    end_time = datetime.datetime.now()
+
+    # Lazy load must return in hopefully much less than 2 secs
+    assert (end_time - start_time).total_seconds() < 1.0
 
     logger.info("Doing asserts")
     assert not vens.files.empty

--- a/tests/test_rmrc.py
+++ b/tests/test_rmrc.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""Testing VirtualEnsembles for RMRC problems."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import numpy as np
+import pandas as pd
+import pytest
+
+import xtgeo
+
+from fmu.ensemble import etc
+from fmu.ensemble import ScratchEnsemble, VirtualEnsemble
+
+fmux = etc.Interaction()
+logger = fmux.basiclogger(__name__, level="INFO")
+
+if not fmux.testsetup():
+    raise SystemExit()
+
+
+def test_rmrc():
+    """Test the properties of a virtualized ScratchEnsemble on JS data"""
+
+    ens_path = "/scratch/johan_sverdrup2/peesv/2019a_b003p2p0_pred_102_9aug_ff_a/"
+    storage = "/scratch/johan_sverdrup2/rmrc/ens1/"
+    iteration_name = "pred"
+    local_paths = ["share/maps/depth", "share/maps/isochores"]
+
+    if not os.path.exists(ens_path):
+        pytest.skip("Test data not available")
+
+    logger.info("Constructing ensemble object from disk")
+    ens = ScratchEnsemble(
+        "ens1", os.path.join(ens_path, "realization-*/{}".format(iteration_name))
+    )
+    logger.info("Loading smry")
+    # ens.load_smry(time_index="monthly")
+    logger.info("Finding *gri files")
+    ens.find_files(
+        "share/maps/depth/*.gri",
+        metadata={"surfacetype": "depthsurface"},
+        metayaml=True,
+    )
+    ens.find_files(
+        "share/maps/isochores/*.gri",
+        metadata={"surfacetype": "isochores"},
+        metayaml=True,
+    )
+    logger.info("Dumping to disk (js_vens_dump)")
+    ens.to_virtual().to_disk(
+        "js_vens_dump", delete=True, dumpcsv=True, includefiles=True, symlinks=True
+    )
+    logger.info("Loading back from disk")
+    vens = VirtualEnsemble(fromdisk="js_vens_dump")
+
+    logger.info("Doing asserts")
+    assert not vens.files.empty
+
+    assert "surfacetype" in vens.files
+    assert set(vens.files["surfacetype"].dropna().unique()) == set(
+        ["depthsurface", "isochores"]
+    )
+
+    for _, surfacefilerow in vens.files[vens.files["FILETYPE"] == "gri"].iterrows():
+        assert os.path.exists(
+            "js_vens_dump/__discoveredfiles/realization-"
+            + str(surfacefilerow["REAL"])
+            + "/"
+            + surfacefilerow["LOCALPATH"]
+        )

--- a/tests/test_virtualensemble.py
+++ b/tests/test_virtualensemble.py
@@ -214,9 +214,19 @@ def test_todisk():
     # Here we could check filesystem equivalence if we want.
 
     vens.to_disk("vens_dumped_csv", delete=True, dumpparquet=False)
-    fromcsvdisk = VirtualEnsemble()
-    fromcsvdisk.from_disk("vens_dumped_csv")
+    fromcsvdisk = VirtualEnsemble(fromdisk="vens_dumped_csv")
+    lazyfromdisk = VirtualEnsemble(fromdisk="vens_dumped_csv", lazy_load=True)
     assert set(vens.keys()) == set(fromcsvdisk.keys())
+    assert set(vens.keys()) == set(lazyfromdisk.keys())
+    assert 'OK' in lazyfromdisk.lazy_frames.keys()
+    assert 'OK' not in lazyfromdisk.data.keys()
+    assert len(fromcsvdisk.get_df("OK")) == len(lazyfromdisk.get_df("OK"))
+    assert 'OK' not in lazyfromdisk.lazy_frames.keys()
+    assert 'OK' in lazyfromdisk.data.keys()
+    assert len(fromcsvdisk.parameters) == len(lazyfromdisk.parameters)
+    assert len(fromcsvdisk.get_df("unsmry--yearly")) == len(
+        lazyfromdisk.get_df("unsmry--yearly")
+    )
 
     vens.to_disk("vens_dumped_parquet", delete=True, dumpcsv=False)
     fromparquetdisk = VirtualEnsemble()

--- a/tests/test_virtualensemble.py
+++ b/tests/test_virtualensemble.py
@@ -175,8 +175,12 @@ def test_todisk():
     vens = reekensemble.to_virtual()
 
     vens.to_disk("vens_dumped", delete=True)
+    assert len(vens) == len(reekensemble)
 
     fromdisk = VirtualEnsemble(fromdisk="vens_dumped")
+
+    # Same number of realizations:
+    assert len(fromdisk) == len(vens)
 
     # Should have all the same keys,
     # but change of order is fine

--- a/tests/test_virtualensemble.py
+++ b/tests/test_virtualensemble.py
@@ -6,11 +6,12 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import numpy as np
 import pandas as pd
 import pytest
 
 from fmu.ensemble import etc
-from fmu.ensemble import ScratchEnsemble
+from fmu.ensemble import ScratchEnsemble, VirtualEnsemble
 
 fmux = etc.Interaction()
 logger = fmux.basiclogger(__name__, level="WARNING")
@@ -38,6 +39,10 @@ def test_virtualensemble():
     # Check that we have data for 5 realizations
     assert len(vens["unsmry--yearly"]["REAL"].unique()) == 5
     assert len(vens["parameters.txt"]) == 5
+
+    # This is the dataframe of discovered files in the ScratchRealization
+    assert isinstance(vens["__files"], pd.DataFrame)
+    assert not vens["__files"].empty
 
     assert "REAL" in vens["STATUS"].columns
 
@@ -148,6 +153,105 @@ def test_virtualensemble():
 
     # Betterdata should be returned as a dictionary
     assert isinstance(vens.agg("min").get_df("betterdata"), dict)
+
+
+def test_todisk():
+    """Test that we can write VirtualEnsembles to the filesystem in a
+    retrievable manner"""
+    if "__file__" in globals():
+        # Easen up copying test code into interactive sessions
+        testdir = os.path.dirname(os.path.abspath(__file__))
+    else:
+        testdir = os.path.abspath(".")
+    reekensemble = ScratchEnsemble(
+        "reektest", testdir + "/data/testensemble-reek001/" + "realization-*/iter-0"
+    )
+
+    reekensemble.load_smry(time_index="monthly", column_keys="*")
+    reekensemble.load_smry(time_index="daily", column_keys="*")
+    reekensemble.load_smry(time_index="yearly", column_keys="F*")
+    reekensemble.load_scalar("npv.txt")
+    reekensemble.load_txt("outputs.txt")
+    vens = reekensemble.to_virtual()
+
+    vens.to_disk("vens_dumped", delete=True)
+
+    fromdisk = VirtualEnsemble(fromdisk="vens_dumped")
+
+    # Should have all the same keys,
+    # but change of order is fine
+    assert set(vens.keys()) == set(fromdisk.keys())
+
+    for frame in vens.keys():
+        if frame == "STATUS":
+            continue
+        # Columns that only contains NaN will not have their
+        # type preserved, this is too much to ask for, especially
+        # with CSV files. So we drop columns with NaN
+        virtframe = vens.get_df(frame).dropna("columns")
+        diskframe = fromdisk.get_df(frame).dropna("columns")
+
+        assert (virtframe.columns == diskframe.columns).all()
+
+        # It would be nice to be able to use pd.Dataframe.equals,
+        # but it is too strict, as columns with mixed type number/strings
+        # will easily be wrong.
+
+        for column in virtframe.columns:
+            if virtframe[column].dtype == object or diskframe[column].dtype == object:
+                # Ensure we only compare strings when working with object dtype
+                assert (
+                    virtframe[column].astype(str).equals(diskframe[column].astype(str))
+                )
+            else:
+                assert virtframe[column].equals(diskframe[column])
+
+    fromdisk.to_disk("vens_double_dumped", delete=True)
+    # Here we could check filesystem equivalence if we want.
+
+    vens.to_disk("vens_dumped_csv", delete=True, dumpparquet=False)
+    fromcsvdisk = VirtualEnsemble()
+    fromcsvdisk.from_disk("vens_dumped_csv")
+    assert set(vens.keys()) == set(fromcsvdisk.keys())
+
+    vens.to_disk("vens_dumped_parquet", delete=True, dumpcsv=False)
+    fromparquetdisk = VirtualEnsemble()
+    fromparquetdisk.from_disk("vens_dumped_parquet")
+    assert set(vens.keys()) == set(fromparquetdisk.keys())
+
+    fromparquetdisk2 = VirtualEnsemble()
+    fromparquetdisk2.from_disk("vens_dumped_parquet", fmt="csv")
+    # Here we will miss a lot of CSV files, because we only wrote parquet:
+    assert len(vens.keys()) > len(fromparquetdisk2.keys())
+
+    fromcsvdisk2 = VirtualEnsemble()
+    fromcsvdisk2.from_disk("vens_dumped_csv", fmt="parquet")
+    # But even if we only try to load parquet files, when CSV
+    # files are found without corresponding parquet, the CSV file
+    # will be read.
+    assert set(vens.keys()) == set(fromcsvdisk2.keys())
+
+    # Test manual intervention:
+    fooframe = pd.DataFrame(data=np.random.randn(3, 3), columns=["FOO", "BAR", "COM"])
+    fooframe.to_csv(os.path.join("vens_dumped", "share/results/tables/randomdata.csv"))
+    manualens = VirtualEnsemble(fromdisk="vens_dumped")
+    assert "share/results/tables/randomdata.csv" not in manualens.keys()
+
+    # Now with correct column header,
+    # but floating point data for realizations..
+    fooframe = pd.DataFrame(data=np.random.randn(3, 3), columns=["REAL", "BAR", "COM"])
+    fooframe.to_csv(os.path.join("vens_dumped", "share/results/tables/randomdata.csv"))
+    manualens = VirtualEnsemble(fromdisk="vens_dumped")
+    assert "share/results/tables/randomdata.csv" not in manualens.keys()
+
+    # Now with correct column header, and with integer data for REAL..
+    fooframe = pd.DataFrame(
+        data=np.random.randint(low=0, high=100, size=(3, 3)),
+        columns=["REAL", "BAR", "COM"],
+    )
+    fooframe.to_csv(os.path.join("vens_dumped", "share/results/tables/randomdata.csv"))
+    manualens = VirtualEnsemble(fromdisk="vens_dumped")
+    assert "share/results/tables/randomdata.csv" in manualens.keys()
 
 
 def test_get_smry_interpolation():

--- a/tests/test_virtualensemble.py
+++ b/tests/test_virtualensemble.py
@@ -40,6 +40,8 @@ def test_virtualensemble():
     assert len(vens["unsmry--yearly"]["REAL"].unique()) == 5
     assert len(vens["parameters.txt"]) == 5
 
+    assert not vens.lazy_keys()
+
     # This is the dataframe of discovered files in the ScratchRealization
     assert isinstance(vens["__files"], pd.DataFrame)
     assert not vens["__files"].empty
@@ -94,7 +96,8 @@ def test_virtualensemble():
 
     # Test virtrealization retrieval:
     vreal = vens.get_realization(2)
-    assert vreal.keys() == vens.keys()
+    assert len(vreal.keys()) == len(vens.keys())
+    assert set(vreal.keys()) == set(vens.keys())  # Order is not preserved
 
     # Test realization removal:
     vens.remove_realizations(3)

--- a/tests/test_virtualensemble.py
+++ b/tests/test_virtualensemble.py
@@ -254,6 +254,36 @@ def test_todisk():
     assert "share/results/tables/randomdata.csv" in manualens.keys()
 
 
+def test_todisk_includefile():
+    """Test that we can write VirtualEnsembles to the filesystem in a
+    retrievable manner with discovered files included"""
+    if "__file__" in globals():
+        # Easen up copying test code into interactive sessions
+        testdir = os.path.dirname(os.path.abspath(__file__))
+    else:
+        testdir = os.path.abspath(".")
+    reekensemble = ScratchEnsemble(
+        "reektest", testdir + "/data/testensemble-reek001/" + "realization-*/iter-0"
+    )
+
+    reekensemble.load_smry(time_index="monthly", column_keys="*")
+    reekensemble.load_smry(time_index="daily", column_keys="*")
+    reekensemble.load_smry(time_index="yearly", column_keys="F*")
+    reekensemble.load_scalar("npv.txt")
+    reekensemble.load_txt("outputs.txt")
+    vens = reekensemble.to_virtual()
+
+    vens.to_disk("vens_dumped_files", delete=True, includefiles=True, symlinks=True)
+    for real in [0, 1, 2, 4, 4]:
+        runpath = os.path.join(
+            "vens_dumped_files", "__discoveredfiles", "realization-" + str(real)
+        )
+        assert os.path.exists(runpath)
+        assert os.path.exists(
+            os.path.join(runpath, "eclipse/model/2_R001_REEK-" + str(real) + ".UNSMRY")
+        )
+
+
 def test_get_smry_interpolation():
     """Test the summary resampling code for virtual ensembles"""
 


### PR DESCRIPTION
Branch created for development of RMRC.

Includes vens_disk branch - this must be matured sufficiently
New features to be added:

VirtualEnsemble.to_disk() support uploading to Azure URLs. Ditto for from_disk()
VirtualEnsemble.to_disk() gets support to include certain files in files dataframe, and transform paths
Scratch/VirtualEnsembles get a new function for aggregating surfaces, that means pr. realization files that can be loaded as xtgeo.RegularSurface objects.
There should be caching support for aggregated surfaces, written back to disk. A VirtualEnsemble then needs to know from where it was initialized via from_disk().
Ensemble objects should support some sort of a manifest with random information. E.g a dictionary in Python, and written to/read from yaml files on disk.
New dependencies:

xtgeo
azure-storage-blob
azure-storage-file