### PR TITLE
WIP: rmrc azuremodule

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,12 +1,15 @@
 # PYLINT: General settings for FMU modules
 
 [GENERAL]
-disable=R0205, F0010, C0330
+disable=R0205, F0010, C0330, E1136
 output-format=colorized
+
+# E1136: Pylint is not able to detect that all objects really are subscriptable
+# E0401: import-error, these will be caught by automated tests anyhow
 
 [MASTER]
 init-hook='import sys; sys.path.append("src/")'
-ignore=_version.py,__init__.py
+ignore=_version.py,__init__.py,setup.py,versioneer.py
 
 [BASIC]
 good-names=logger, fmux, xfmu

--- a/.pylintrc
+++ b/.pylintrc
@@ -9,7 +9,7 @@ output-format=colorized
 
 [MASTER]
 init-hook='import sys; sys.path.append("src/")'
-ignore=_version.py,__init__.py,setup.py,versioneer.py,data
+ignore=_version.py,__init__.py,setup.py,versioneer.py,jobs.py
 
 [BASIC]
 good-names=logger, fmux, xfmu

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,7 +1,7 @@
 # PYLINT: General settings for FMU modules
 
 [GENERAL]
-disable=R0205, F0010, C0330, E1136
+disable=R0205, F0010, C0330, E1136, E0401
 output-format=colorized
 
 # E1136: Pylint is not able to detect that all objects really are subscriptable
@@ -9,7 +9,7 @@ output-format=colorized
 
 [MASTER]
 init-hook='import sys; sys.path.append("src/")'
-ignore=_version.py,__init__.py,setup.py,versioneer.py
+ignore=_version.py,__init__.py,setup.py,versioneer.py,data
 
 [BASIC]
 good-names=logger, fmux, xfmu

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ python:
   - "2.7"
   - "3.6"
 
+addons:
+  apt:
+    packages:
+      - libsnappy-dev
+
 before_install:
   - pushd ..
   - export ROOT="$PWD"

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -4,15 +4,15 @@
 Contributing
 ============
 
-Contributions are welcome, and they are greatly appreciated! Every
+Contributions are welcome, and they are greatly appreciated. Every
 little bit helps, and credit will always be given.
 
 You can contribute in many ways:
 
-Types of Contributions
+Types of contributions
 ----------------------
 
-Report Bugs
+Report bugs
 ~~~~~~~~~~~
 
 Report bugs at https://github.com/equinor/fmu-ensemble/issues.
@@ -23,19 +23,19 @@ If you are reporting a bug, please include:
 * Any details about your local setup that might be helpful in troubleshooting.
 * Detailed steps to reproduce the bug.
 
-Fix Bugs
+Fix bugs
 ~~~~~~~~
 
 Look through the Git issues for bugs. Anything tagged with "bug"
 and "help wanted" is open to whoever wants to implement it.
 
-Implement Features
+Implement features
 ~~~~~~~~~~~~~~~~~~
 
 Look through the Git issues for features. Anything tagged with "enhancement"
 and "help wanted" is open to whoever wants to implement it.
 
-Write Documentation
+Write documentation
 ~~~~~~~~~~~~~~~~~~~
 
 fmu-ensemble could always use more documentation, whether as part of the
@@ -52,9 +52,6 @@ If you are proposing a feature:
 
 * Explain in detail how it would work.
 * Keep the scope as narrow as possible, to make it easier to implement.
-* Remember that this is a volunteer-driven project, and that contributions
-  are welcome :)
-
 
 Code standards
 --------------
@@ -64,35 +61,31 @@ It is very important to be complient to code standards. A summary:
 PEP8 and PEP20
 ~~~~~~~~~~~~~~
 
-* Use PEP8 standard (https://www.python.org/dev/peps/pep-0008/) and PEP20 philosophy.
-  This implies:
+* Use PEP8 standard (https://www.python.org/dev/peps/pep-0008/) and PEP20 philosophy, with line length set 88.
 
-  * Line width max 79
+* Use the source code formatter black (https://github.com/python/black)
 
-  * Naming: files_as_this, ClassesAsThis, ExceptionsAsThis, CONSTANTS,
-    function_as_this, method_as_this
+* Naming: `files_as_this`, `ClassesAsThis`, `ExceptionsAsThis`, `CONSTANTS`,
+  `function_as_this`, `method_as_this`
 
-  * Use a single underscore to protect instance variables, other private
-    variables and and private classes
+* Use a single underscore to protect instance variables, other private
+  variables and and private classes
 
-  * 4 space indents (spaces, no tabs)
+* 4 space indents (spaces, no tabs)
 
-  * Single quotes to delimit strings, triple double quotes in docstrings.
+* One space before and after `=`, `+`, `*` etc
 
-  * One space before and after =, =, +, * etc
+* No space around `=` in keyword lists, e.g. `my_function(value=27, default=None)`
 
-  * No space around  = in keword lists, e.g. my_function(value=27, default=None)
-
-  * Avoid one or two letter variables, even for counters. And meaningful names, but don't
-    overdo it.
-
+* Avoid one or two letter variables, even for counters. And meaningful
+  names, but don't overdo it.
 
 In addition:
 ~~~~~~~~~~~~
 
 * Start with documentation and tests. Think and communicate first!
 
-* Docstrings shall start and end with """ and use Google style.
+* Docstrings shall start and end with `"""`.
 
 * Use pytest as testing engine
 
@@ -102,12 +95,17 @@ In addition:
 Use flake8 and/or pylint to check
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  python -m flake8 mycode.py
+.. code-block:: console
 
-  make flake   # for all
+    python -m flake8 mycode.py
+
+    make flake   # for all
 
 The pylint is rather strict and sometimes exceptions are needed... , but anyway quite useful!
 
-  python -m pylint mycode.py
+.. code-block:: console
 
-  make lint   # for all
+    python -m pylint mycode.py
+
+    make lint   # for all
+

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 Commit history
 --------------
 
-See commit log on github.
+See commit log on github, https://github.com/equinor/fmu-ensemble/commits/
 
 First open release (GPLv3) in June 2019.
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+.. image:: https://travis-ci.com/equinor/fmu-ensemble.svg?branch=master
+    :target: https://travis-ci.com/equinor/fmu-ensemble
+
+.. image:: https://api.codacy.com/project/badge/Grade/33b0d3049b634ff2b4dfc6cc791d7da7
+    :target: https://www.codacy.com/app/anders-kiaer/fmu-ensemble?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=equinor/fmu-ensemble&amp;utm_campaign=Badge_Grade
+
 ==============================
 Introduction to *fmu.ensemble*
 ==============================
@@ -5,11 +11,11 @@ Introduction to *fmu.ensemble*
 FMU Ensemble is a Python module for handling simulation ensembles
 originating from an FMU (Fast Model Update) workflow.
 
-For documentation, see the 
+For documentation, see the
 `github pages for this repository <https://equinor.github.io/fmu-ensemble/>`_.
 
 Ensembles consist of realizations. Realizations consist of (input and)
-output from their associated *jobs* stored in text or binary files. 
+output from their associated *jobs* stored in text or binary files.
 Selected file formats (text and binary) are supported.
 
 This module will help you handle ensembles and realizations (and their

--- a/docs/advancedusage.rst
+++ b/docs/advancedusage.rst
@@ -130,7 +130,7 @@ like:
     smryh:
       - key: FOPT
         histvec: FOPTH
-        time_index: monthly  # or yearly, daily, raw or last
+        time_index: monthly  # or yearly, daily, raw or last, or a ISO-date
 
 This file can be loaded in Python:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ numpy
 pandas>0.23.0
 six>=1.12.0
 pyarrow
-parquet
 xtgeo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 pyyaml>=5.1
 wheel>=0.29.0
 pylint
+numpy
 pandas>0.23.0
 six>=1.12.0
+pyarrow
+parquet

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pandas>0.23.0
 six>=1.12.0
 pyarrow
 parquet
+xtgeo

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,3 +14,5 @@ astroid
 pylint
 pandas>0.23.0
 six>=1.12.0
+parquet
+pyarrow

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -16,3 +16,4 @@ pandas>0.23.0
 six>=1.12.0
 parquet
 pyarrow
+xtgeo

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 universal = 1
 
 [flake8]
+max-line-length = 88
 exclude = docs,
     tests/data
 

--- a/src/fmu/ensemble/__init__.py
+++ b/src/fmu/ensemble/__init__.py
@@ -16,3 +16,4 @@ from .virtualensemble import VirtualEnsemble  # noqa
 from .ensemblecombination import EnsembleCombination  # noqa
 from .realizationcombination import RealizationCombination  # noqa
 from .observations import Observations  # noqa
+from .azureensemble import AzureScratchEnsemble # noqa

--- a/src/fmu/ensemble/__init__.py
+++ b/src/fmu/ensemble/__init__.py
@@ -17,3 +17,4 @@ from .ensemblecombination import EnsembleCombination  # noqa
 from .realizationcombination import RealizationCombination  # noqa
 from .observations import Observations  # noqa
 from .azureensemble import AzureScratchEnsemble # noqa
+from .azureensemble import AzureScratchRealization # noqa

--- a/src/fmu/ensemble/_theversion.py
+++ b/src/fmu/ensemble/_theversion.py
@@ -10,19 +10,19 @@ from fmu.ensemble._version import get_versions
 def theversion():
     """Get version on proper form."""
     versions = get_versions()
-    version = versions['version']
-    sver = version.split('.')
+    version = versions["version"]
+    sver = version.split(".")
 
-    useversion = 'UNSET'
+    useversion = "UNSET"
     if len(sver) == 3:
         useversion = version
     else:
-        bugv = sver[2].replace('+', '.')
+        bugv = sver[2].replace("+", ".")
 
-        if 'dirty' in version:
-            ext = '.dev0'
+        if "dirty" in version:
+            ext = ".dev0"
         else:
-            ext = ''
-        useversion = '{}.{}.{}{}'.format(sver[0], sver[1], bugv, ext)
+            ext = ""
+        useversion = "{}.{}.{}{}".format(sver[0], sver[1], bugv, ext)
 
     return useversion

--- a/src/fmu/ensemble/_version.py
+++ b/src/fmu/ensemble/_version.py
@@ -57,17 +57,18 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -75,10 +76,13 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=(subprocess.PIPE if hide_stderr
-                                         else None))
+            p = subprocess.Popen(
+                [c] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+            )
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -115,16 +119,22 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(
+            "Tried directories %s but none started with prefix %s"
+            % (str(rootdirs), parentdir_prefix)
+        )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -180,7 +190,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -189,7 +199,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -197,19 +207,26 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -224,8 +241,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                          hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -233,10 +249,19 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
-                                   cwd=root)
+    describe_out, rc = run_command(
+        GITS,
+        [
+            "describe",
+            "--tags",
+            "--dirty",
+            "--always",
+            "--long",
+            "--match",
+            "%s*" % tag_prefix,
+        ],
+        cwd=root,
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -259,17 +284,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -278,10 +302,12 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+                full_tag,
+                tag_prefix,
+            )
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -292,13 +318,13 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                    cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
-                       cwd=root)[0].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[
+        0
+    ].strip()
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
@@ -329,8 +355,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -444,11 +469,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -468,9 +495,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 def get_versions():
@@ -484,8 +515,7 @@ def get_versions():
     verbose = cfg.verbose
 
     try:
-        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
-                                          verbose)
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix, verbose)
     except NotThisMethod:
         pass
 
@@ -494,13 +524,16 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split('/'):
+        for i in cfg.versionfile_source.split("/"):
             root = os.path.dirname(root)
     except NameError:
-        return {"version": "0+unknown", "full-revisionid": None,
-                "dirty": None,
-                "error": "unable to find root of source tree",
-                "date": None}
+        return {
+            "version": "0+unknown",
+            "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to find root of source tree",
+            "date": None,
+        }
 
     try:
         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
@@ -514,6 +547,10 @@ def get_versions():
     except NotThisMethod:
         pass
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None,
-            "error": "unable to compute version", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }

--- a/src/fmu/ensemble/azureensemble.py
+++ b/src/fmu/ensemble/azureensemble.py
@@ -121,7 +121,6 @@ class AzureScratchEnsemble():
                 raise ValueError('Non-valid searchpaths given')
 
         # create a scratchensemble
-        print(self._searchpaths)
         self.scratchensemble = self.build_scratchensemble(self._ensemble_name,
                                                           self._ensemble_path,
                                                           self._searchpaths)
@@ -193,7 +192,6 @@ class AzureScratchEnsemble():
            is not in use, make it, return the path """
 
         if not os.path.isdir(tmp_storage_root):
-            print(tmp_storage_root)
             logger.critical('Non-valid temporary storage path given: {}'.format(tmp_storage_root))
             raise IOError('Not a valid temporary storage: {}'.format(tmp_storage_root))
 

--- a/src/fmu/ensemble/azureensemble.py
+++ b/src/fmu/ensemble/azureensemble.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+"""Module containing classes related to Azure and RMRC storage
+"""
+
+
+class AzureScratchEnsemble():
+    """Class for handling ensembles that are to be uploaded to the RMrC
+       storage on Azure. Class is initialized in an ensemble-centric way,
+       initializes a ScratchEnsemble object, which in turn initializes a
+       VirtualEnsemble object
+
+    Args:
+        ensemble_name (str): Name of ensemble. Will be passed to ScratchEnsemble
+        ensemble_path (path): Path to root of ensemble
+        manifest_path (path): 
+
+    TODO:
+        - tmp_storage_path to be replaced by a /tmp/<random>
+
+    """
+
+    def __init__(self,
+        ensemble_name,
+        ensemble_path,
+        iter_name,
+        manifest_path,
+        tmp_storage_path,        # DEV ONLY, will be replaced
+        searchpaths=None,
+        ):
+
+        self._ensemble_name = ensemble_name
+        self._ensemble_path = self.confirm_ensemble_path(ensemble_path)
+        self._iter_name = iter_name
+        self._manifest = self.parse_manifest(manifest_path)
+
+        self._index = None
+
+        if searchpaths is None:
+            # assume all files to be indexed
+            # for now just a dummy path
+            searchpaths = ['share/maps/*/*.*', 
+                           #'share/maps/isochores/*.*',
+                           #'share/maps/recoverables/*.*'
+                          ]
+        else:
+            if isinstance(searchpaths, str):
+                searchpaths = [searchpaths]
+            else:
+                pass
+
+        # create a scratchensemble
+        self.scratchensemble = self.build_scratchensemble(self._ensemble_name,
+                                                          self._ensemble_path,
+                                                          searchpaths)
+
+        # create a VirtualEnsemble
+        vens = self.scratchensemble.to_virtual()
+
+        # add smry data
+        smry = self.scratchensemble.get_smry()
+        vens.append('shared--smry', smry)   # shared is indicating that data goes across realizations
+
+        # add x
+
+        # add y
+        
+        # Dump to disk ready for upload
+        prepare_blob_structure(temporary_filesystempath)
+
+        # DATA section
+        copy_files(temporary_filesystempath)
+        dump_internalized_dataframes(temporary_filesystempath)
+
+        # MANIFEST section
+        dump_manifest(temporary_filesystempath)
+
+        # INDEX section
+        self.index = self.vens.files()
+        self.dump_index(temporary_filesystempath)
+
+        print('OK')
+
+        # TODO authentication towards azure go here, returns a token
+        # TODO some checks towards the storage (already existing ensemble, etc) goes here
+        # TODO upload function with the returned token go here
+        # TODO some confirmation functions (just API calls?) go here
+
+    @property
+    def manifest(self):
+        return self._manifest
+
+
+    def prepare_blob_structure(self, filesystempath, delete=False):
+        """Prepare a directory for dumping a virtual ensemble.
+
+        The end result is either an error, or a clean empty directory
+        at the requested path"""
+        if os.path.exists(filesystempath):
+            if delete:
+                shutil.rmtree(filesystempath)
+                os.mkdir(filesystempath)
+            else:
+                if os.listdir(filesystempath):
+                    logger.critical(
+                        "Refusing to write virtual ensemble "
+                        + " to non-empty directory"
+                    )
+                    raise IOError("Directory %s not empty" % filesystempath)
+        else:
+            os.mkdir(filesystempath)
+            os.mkdir(os.path.join(filesystempath, "data"))
+            os.mkdir(os.path.join(filesystempath, "data/share"))
+            os.mkdir(os.path.join(filesystempath, "manifest"))
+            os.mkdir(os.path.join(filesystempath, "index"))
+
+    def copy_files(self, filesystempath, localdir="data"):
+
+        # code from .to_disk()
+        for _, filerow in self.files.iterrows():
+            src_fpath = filerow["FULLPATH"]
+            dest_fpath = os.path.join(
+                filesystempath,
+                localdir,
+                "realization-" + str(filerow["REAL"]),
+                filerow["LOCALPATH"],
+            )
+            directory = os.path.dirname(dest_fpath)
+            if not os.path.exists(directory):
+                os.makedirs(os.path.dirname(dest_fpath))
+            shutil.copy(src_fpath, dest_fpath)
+
+
+    def dump_manifest(self, filesystempath, localdir="manifest"):
+        """Dump the internalized ensemble manifest to disk"""
+
+        # initialise it with some values we might want to inject
+        compiled_manifest = {'rmrc' : {'SomeKey' : 'SomeValue',
+                                       'SomeOtherKey' : 'SomeValue'
+                                       }
+                            }
+
+        if self._manifest is not None:
+            compiled_manifest.update(self._manifest)
+
+        dest_fpath = os.path.join(
+            filesystempath,
+            localdir,
+            'manifest.yaml')
+
+        with open(dest_fpath, 'w+') as outfile:
+            yaml.dump(compiled_manifest, outfile, default_flow_style=False)
+
+        print('yaml dumped')
+
+    def create_index(self, filesystempath, localdir="index", indexfname="index.csv"):
+        """Assemble index as dataframe
+
+        TODO: Explore possibility of using json
+        TODO: Explore extension of metadata fields
+        """
+
+        indexpath = os.path.join(filesystempath, localdir, indexfname)
+        return 
+
+
+        # parse metadata if present for each file, append to the index.
+        # should be code for this elsewhere...
+
+
+
+    def dump_index(self, filesystempath, localdir="index", indexfname="index.csv"):
+        """Dump the index to disk"""
+        self.files.to_csv(indexpath, index=False)
+        print('index dumped')
+
+
+    def dump_internalized_dataframes(self, filesystempath, localdir="data/share"):
+        """Dump dataframes carried by the ScratchEnsemble object for tabular
+           data to disk. Return information that must be appended to index."""
+
+        print('dumping internal dataframes')
+
+        for key in self.data:
+            fname = os.path.join(filesystempath, localdir, str(key)+'.csv')
+            print('dumping {}'.format(fname))
+            self.data[key].to_csv(fname, index=False)
+
+        # return index info here | or print to __files?
+
+
+

--- a/src/fmu/ensemble/azureensemble.py
+++ b/src/fmu/ensemble/azureensemble.py
@@ -237,7 +237,7 @@ class AzureScratchEnsemble():
 
         if isinstance(ignoredirs, list):
 
-            ignoredirs = tuple(['/' + d if not d.startswith('/') else d for d in ignoredirs])
+            ignoredirs = tuple([d[1:] if d.startswith('/') else d for d in ignoredirs])
 
             for subdir in subdirs:
                 if not subdir.startswith(ignoredirs) and len(subdir) > 0:

--- a/src/fmu/ensemble/ensemble.py
+++ b/src/fmu/ensemble/ensemble.py
@@ -339,15 +339,33 @@ class ScratchEnsemble(object):
         aggregated and stored as dataframes in the returned
         VirtualEnsemble
 
+        Unless specified, the VirtualEnsemble object wil
+        have the same 'name' as the ScratchEnsemble.
+
         Args:
             name (str): Name of the ensemble as virtualized.
         """
+        if not name:
+            name = self._name
         vens = VirtualEnsemble(name=name)
 
         for key in self.keys():
             vens.append(key, self.get_df(key))
         vens.update_realindices()
+
+        # __files is the magic name for the dataframe of
+        # loaded files.
+        vens.append("__files", self.files)
         return vens
+
+    def to_disk(self, filesystempath, delete=False, dumpcsv=True, dumpparquet=True):
+        """Dump ensemble data to a directory on disk.
+
+        The ScratchEnsemble is first converted to a VirtualEnsemble,
+        which is then dumped to disk. This function is a
+        convenience wrapper for to_disk() in VirtualEnsemble.
+        """
+        self.to_virtual().to_disk(filesystempath, delete, dumpcsv, dumpparquet)
 
     @property
     def parameters(self):

--- a/src/fmu/ensemble/ensemble.py
+++ b/src/fmu/ensemble/ensemble.py
@@ -453,14 +453,21 @@ class ScratchEnsemble(object):
             raise ValueError("No ensemble data found for %s", localpath)
         return self.get_df(localpath)
 
-    def find_files(self, paths, metadata=None):
+    def find_files(self, paths, metadata=None, metayaml=False):
         """Discover realization files. The files dataframes
         for each realization will be updated.
 
         Certain functionality requires up-front file discovery,
         e.g. ensemble archiving and ensemble arithmetic.
 
-        CSV files for single use does not have to be discovered.
+        CSV files for single use do not have to be discovered.
+
+        Files containing double-dashes '--' indicate that the double
+        dashes separate different component with meaning in the
+        filename.  The components are extracted and put into
+        additional columns "COMP1", "COMP2", etc..
+        Filetype extension (after the last dot) will be removed
+        from the last component.
 
         Args:
             paths (str or list of str): Filenames (will be globbed)
@@ -468,13 +475,23 @@ class ScratchEnsemble(object):
             metadata (dict): metadata to assign for the discovered
                 files. The keys will be columns, and its values will be
                 assigned as column values for the discovered files.
+            metayaml: Additional possibility of adding metadata from
+                associated yaml files. Yaml files to be associated to
+                a specific discovered file can have an optional dot in
+                front, and must end in .yml, added to the discovered filename.
+                The yaml file will be loaded as a dict, and have its keys
+                flattened using the separator '--'. Flattened keys are
+                then used as column headers in the returned dataframe.
+
         Returns:
             pd.DataFrame: with the slice of discovered files in each
             realization, tagged with realization index in the column REAL
         """
         df_list = {}
         for index, realization in self._realizations.items():
-            df_list[index] = realization.find_files(paths, metadata)
+            df_list[index] = realization.find_files(
+                paths, metadata=metadata, metayaml=metayaml
+            )
         if df_list:
             return (
                 pd.concat(df_list, sort=False)

--- a/src/fmu/ensemble/ensemble.py
+++ b/src/fmu/ensemble/ensemble.py
@@ -347,6 +347,7 @@ class ScratchEnsemble(object):
         """
         if not name:
             name = self._name
+        logger.info("Creating virtual ensemble named %s", str(name))
         vens = VirtualEnsemble(name=name)
 
         for key in self.keys():

--- a/src/fmu/ensemble/ensemble.py
+++ b/src/fmu/ensemble/ensemble.py
@@ -9,9 +9,9 @@ from __future__ import print_function
 import re
 import os
 import glob
-import six
+from datetime import datetime
 
-from datetime import datetime, date, time
+import six
 import pandas as pd
 import numpy as np
 from ecl import EclDataType
@@ -283,10 +283,10 @@ class ScratchEnsemble(object):
             ):
                 raise ValueError("runpath dataframe not correct")
 
-        for idx, row in runpath_df.iterrows():
+        for _, row in runpath_df.iterrows():
             if runpathfilter and runpathfilter not in row["runpath"]:
                 continue
-            logger.info("Adding realization from " + row["runpath"])
+            logger.info("Adding realization from %s", row["runpath"])
             realization = ScratchRealization(
                 row["runpath"], index=int(row["index"]), autodiscovery=False
             )
@@ -475,7 +475,7 @@ class ScratchEnsemble(object):
             metadata (dict): metadata to assign for the discovered
                 files. The keys will be columns, and its values will be
                 assigned as column values for the discovered files.
-            metayaml: Additional possibility of adding metadata from
+            metayaml (boolean): Additional possibility of adding metadata from
                 associated yaml files. Yaml files to be associated to
                 a specific discovered file can have an optional dot in
                 front, and must end in .yml, added to the discovered filename.
@@ -485,7 +485,8 @@ class ScratchEnsemble(object):
 
         Returns:
             pd.DataFrame: with the slice of discovered files in each
-            realization, tagged with realization index in the column REAL
+                realization, tagged with realization index in the column REAL.
+                Empty dataframe if no files found.
         """
         df_list = {}
         for index, realization in self._realizations.items():
@@ -499,6 +500,7 @@ class ScratchEnsemble(object):
                 .rename(columns={"level_0": "REAL"})
                 .drop("level_1", axis="columns")
             )
+        return pd.DataFrame()
 
     def __repr__(self):
         return "<ScratchEnsemble {}, {} realizations>".format(self.name, len(self))
@@ -1182,7 +1184,7 @@ class ScratchEnsemble(object):
             if not (int in dtypes or float in dtypes):
                 logger.info("No numerical data to aggregate in %s", key)
                 continue
-            if len(groupby):
+            if groupby:
                 logger.info("Grouping %s by %s", key, groupby)
                 aggobject = data.groupby(groupby)
             else:
@@ -1437,6 +1439,7 @@ class ScratchEnsemble(object):
         if agg == "std":
             std_dev = self._keyword_std_dev(prop, self.global_active, mean)
             return pd.Series(std_dev.numpy_copy(), name=prop)
+        return pd.Series()
 
     def get_unrst(self, prop, report, agg):
         """
@@ -1455,6 +1458,7 @@ class ScratchEnsemble(object):
                 prop, self.global_active, mean, report=report
             )
             return pd.Series(std_dev.numpy_copy(), name=prop)
+        return pd.Series()
 
     def _keyword_mean(self, prop, global_active, report=None):
         """
@@ -1488,7 +1492,7 @@ class ScratchEnsemble(object):
         """
         if report:
             std_dev = EclKW(prop, len(global_active), EclDataType.ECL_FLOAT)
-            for real, realization in six.iteritems(self._realizations):
+            for _, realization in six.iteritems(self._realizations):
                 real_prop = realization.get_global_unrst_keyword(prop, report)
                 std_dev.add_squared(real_prop - mean)
             std_dev.safe_div(global_active)

--- a/src/fmu/ensemble/ensemble.py
+++ b/src/fmu/ensemble/ensemble.py
@@ -40,6 +40,7 @@ class ScratchEnsemble(object):
     by their realization index (integer).
 
     Example for initialization:
+
         >>> from fmu import ensemble
         >>> ens = ensemble.ScratchEnsemble('ensemblename',
                     '/scratch/fmu/foobert/r089/casename/realization-*/iter-0')
@@ -55,18 +56,18 @@ class ScratchEnsemble(object):
             to file system. Absolute or relative paths.
             If omitted, ensemble will be empty unless runpathfile
             is used.
-        realidxregexp: str or regexp - used to deduce the realization index
+        realidxregexp (str or regexp): used to deduce the realization index
             from the file path. Default tailored for realization-X
-        runpathfile: str. Filename (absolute or relative) of an ERT
+        runpathfile (str): Filename (absolute or relative) of an ERT
             runpath file, consisting of four space separated text fields,
             first column is realization index, second column is absolute
             or relative path to a realization RUNPATH, third column is
             the basename of the Eclipse simulation, relative to RUNPATH.
             Fourth column is not used.
-        runpathfilter: str. If supplied, the only the runpaths in
+        runpathfilter (str): If supplied, the only the runpaths in
             the runpathfile which contains this string will be included
             Use to select only a specific realization f.ex.
-        autodiscovery: boolean. True by default, means that the class
+        autodiscovery (boolean): True by default, means that the class
             can try to autodiscover data in the realization. Turn
             off to gain more fined tuned control.
     """
@@ -144,7 +145,8 @@ class ScratchEnsemble(object):
         """
         Return the union of all keys available in realizations.
 
-        Keys refer to the realization datastore, a dictionary
+        Keys refer to the realization datastore of internalized
+        data. The datastore is a dictionary
         of dataframes or dicts. Examples would be `parameters.txt`,
         `STATUS`, `share/results/tables/unsmry--monthly.csv`
         """
@@ -159,8 +161,11 @@ class ScratchEnsemble(object):
         within the datastore.
 
         If the fully qualified localpath is
+
             'share/results/volumes/simulator_volume_fipnum.csv'
+
         then you can also access this with these alternatives:
+
          * simulator_volume_fipnum
          * simulator_volume_fipnum.csv
          * share/results/volumes/simulator_volume_fipnum
@@ -202,7 +207,7 @@ class ScratchEnsemble(object):
         Args:
             paths (list/str): String or list of strings with wildcards
                 to file system. Absolute or relative paths.
-            autodiscovery: boolean, whether files can be attempted
+            autodiscovery (boolean): whether files can be attempted
                 auto-discovered
 
         Returns:
@@ -249,13 +254,13 @@ class ScratchEnsemble(object):
           * iter - integer with the iteration number.
 
         Args:
-            runpath: str with filename, absolute or relative, or
+            runpath (str): Filename, absolute or relative, or
                 a Pandas DataFrame parsed from a runpath file
-            runpathfilter: str which each filepath has to match
+            runpathfilter (str). A filter which each filepath has to match
                 in order to be included. Default None which means not filter
 
         Returns:
-            int - Number of successfully added realizations.
+            int: Number of successfully added realizations.
         """
         prelength = len(self)
         if isinstance(runpath, str):
@@ -298,12 +303,12 @@ class ScratchEnsemble(object):
         datastores. This modifies the underlying realization
         objects, and is equivalent to
 
-        >>> del realization[localpath]
+            >>> del realization[localpath]
 
         on each realization in the ensemble.
 
         Args:
-            localpath: string with full localpath to
+            localpath (string): Full localpath to
                 the data, or list of strings.
         """
         if isinstance(localpaths, str):
@@ -316,7 +321,7 @@ class ScratchEnsemble(object):
         """Remove specific realizations from the ensemble
 
         Args:
-            realindices: int or list of ints for the realization
+            realindices (int or list of ints): The realization
                 indices to be removed
         """
         if isinstance(realindices, int):
@@ -333,6 +338,9 @@ class ScratchEnsemble(object):
         This means that all imported data in each realization is
         aggregated and stored as dataframes in the returned
         VirtualEnsemble
+
+        Args:
+            name (str): Name of the ensemble as virtualized.
         """
         vens = VirtualEnsemble(name=name)
 
@@ -358,17 +366,17 @@ class ScratchEnsemble(object):
         Parsing is performed individually in each realization
 
         Args:
-            localpath: path to the text file, relative to each realization
-            convert_numeric: If set to True, assume that
+            localpath (str): path to the text file, relative to each realization
+            convert_numeric (boolean): If set to True, assume that
                 the value is numerical, and treat strings as
                 errors.
-            force_reread: Force reread from file system. If
+            force_reread (boolean): Force reread from file system. If
                 False, repeated calls to this function will
                 returned cached results.
         Returns:
-            DataFrame, with aggregated data over the ensemble. The column 'REAL'
-                signifies the realization indices, and a column with the same
-                name as the localpath filename contains the data.
+            pd.DataFrame: Aggregated data over the ensemble. The column 'REAL'
+            signifies the realization indices, and a column with the same
+            name as the localpath filename contains the data.
 
         """
         return self.load_file(localpath, "scalar", convert_numeric, force_reread)
@@ -377,7 +385,9 @@ class ScratchEnsemble(object):
         """Parse a key-value text file from disk and internalize data
 
         Parses text files on the form
-        <key> <value>
+
+            <key> <value>
+
         in each line.
 
         Parsing is performed individually in each realization
@@ -389,21 +399,21 @@ class ScratchEnsemble(object):
 
         The CSV file must be present in at least one realization.
         The parsing is done individually for each realization, and
-        aggregation is on demand (through get_df()) and when
+        aggregation is on demand (through `get_df()`) and when
         this function returns.
 
         Args:
-            localpath: path to the text file, relative to each realization
-            convert_numeric: If set to True, numerical columns
+            localpath (str): path to the text file, relative to each realization
+            convert_numeric (boolean): If set to True, numerical columns
                 will be searched for and have their dtype set
                 to integers or floats. If scalars, only numerical
                 data will be loaded.
-            force_reread: Force reread from file system. If
+            force_reread (boolean): Force reread from file system. If
                 False, repeated calls to this function will
                 returned cached results.
         Returns:
-            Dataframe, aggregation of the loaded CSV files. Column 'REAL'
-                distuinguishes each realizations data.
+            pd.Dataframe: aggregation of the loaded CSV files. Column 'REAL'
+            distuinguishes each realizations data.
         """
         return self.load_file(localpath, "csv", convert_numeric, force_reread)
 
@@ -413,19 +423,19 @@ class ScratchEnsemble(object):
         This function may utilize multithreading.
 
         Args:
-            localpath: path to the text file, relative to each realization
-            fformat: string identifying the file format. Supports 'txt'
+            localpath (str): path to the text file, relative to each realization
+            fformat (str): string identifying the file format. Supports 'txt'
                 and 'csv'.
-            convert_numeric: If set to True, numerical columns
+            convert_numeric (boolean): If set to True, numerical columns
                 will be searched for and have their dtype set
                 to integers or floats. If scalars, only numerical
                 data will be loaded.
-            force_reread: Force reread from file system. If
+            force_reread (boolean): Force reread from file system. If
                 False, repeated calls to this function will
                 returned cached results.
         Returns:
-            Dataframe with loaded data aggregated. Column 'REAL'
-                distuinguishes each realizations data.
+            pd.Dataframe: with loaded data aggregated. Column 'REAL'
+            distuinguishes each realizations data.
         """
         for index, realization in self._realizations.items():
             try:
@@ -453,13 +463,13 @@ class ScratchEnsemble(object):
         CSV files for single use does not have to be discovered.
 
         Args:
-            paths: str or list of str with filenames (will be globbed)
+            paths (str or list of str): Filenames (will be globbed)
                 that are relative to the realization directory.
-            metadata: dict with metadata to assign for the discovered
+            metadata (dict): metadata to assign for the discovered
                 files. The keys will be columns, and its values will be
                 assigned as column values for the discovered files.
         Returns:
-            DataFrame with the slice of discovered files in each
+            pd.DataFrame: with the slice of discovered files in each
             realization, tagged with realization index in the column REAL
         """
         df_list = {}
@@ -485,10 +495,10 @@ class ScratchEnsemble(object):
         in all realizations (union).
 
         Args:
-            vector_match: `Optional`. String (or list of strings)
-               with wildcard filter. If None, all vectors are returned
+            vector_match (str or list of str): Wildcards for vectors
+               to obtain. If None, all vectors are returned
         Returns:
-            list of strings with summary vectors. Empty list if no
+            list of str: Matched summary vectors. Empty list if no
             summary file or no matched summary file vectors
         """
         if isinstance(vector_match, str):
@@ -515,11 +525,11 @@ class ScratchEnsemble(object):
         Each row is tagged by the realization index in the column 'REAL'
 
         Args:
-            localpath: string, refers to the internalized name.
+            localpath (str): refers to the internalized name.
         Returns:
-           dataframe: Merged data from each realization.
-               Realizations with missing data are ignored.
-               Empty dataframe if no data is found
+           pd.dataframe: Merged data from each realization.
+           Realizations with missing data are ignored.
+           Empty dataframe if no data is found
         """
         dflist = {}
         for index, realization in self._realizations.items():
@@ -583,35 +593,35 @@ class ScratchEnsemble(object):
         differing from realizations which use raw dates by default.
 
         Args:
-            time_index: list of DateTime if interpolation is wanted.
+            time_index (str or list of DateTime):
                 If defaulted, the raw Eclipse report times will be used.
                 If a string is supplied, that string is attempted used
                 via get_smry_dates() in order to obtain a time index,
                 typically 'monthly', 'daily' or 'yearly'.
-            column_keys: str or list of column key wildcards. Default is '*'
+            column_keys (str or list of str): column key wildcards. Default is '*'
                 which will match all vectors in the Eclipse output.
-            stacked: boolean determining the dataframe layout. If
+            stacked (boolean): determining the dataframe layout. If
                 true, the realization index is a column, and dates are repeated
                 for each realization in the DATES column.
                 If false, a dictionary of dataframes is returned, indexed
                 by vector name, and with realization index as columns.
                 This only works when time_index is the same for all
                 realizations. Not implemented yet!
-            cache_eclsum: Boolean for whether we should cache the EclSum
+            cache_eclsum (boolean): Boolean for whether we should cache the EclSum
                 objects. Set to False if you cannot keep all EclSum files in
                 memory simultaneously
-            start_date: str or date with first date to include.
+            start_date (str or date): First date to include.
                 Dates prior to this date will be dropped, supplied
                 start_date will always be included. If string, use
                 ISO-format, YYYY-MM-DD.
-            end_date: str or date with last date to be included.
+            end_date (str or date): Last date to be included.
                 Dates past this date will be dropped, supplied
                 end_date will always be included. Overriden if time_index
                 is 'last'. If string, use ISO-format, YYYY-MM-DD.
-            include_restart: boolean sent to libecl for wheter restarts
+            include_restart (boolean): boolean sent to libecl for wheter restarts
                 files should be traversed
         Returns:
-            A DataFame of summary vectors for the ensemble, or
+            pd.DataFame: Summary vectors for the ensemble, or
             a dict of dataframes if stacked=False.
         """
         if not stacked:
@@ -651,11 +661,11 @@ class ScratchEnsemble(object):
         are valid backwards in time.
 
         Args:
-            column_keys: str or list of strings, cumulative summary vectors
-            time_index: str or list of datetimes
+            column_keys (str or list of str): cumulative summary vectors
+            time_index (str or list of datetimes):
 
         Returns:
-            DataFrame analoguous to the dataframe returned by get_smry().
+            pd.DataFrame: analoguous to the dataframe returned by get_smry().
             Empty dataframe if no data found.
         """
         vol_dfs = []
@@ -686,19 +696,19 @@ class ScratchEnsemble(object):
         value, for example filtering on a specific sensitivity case.
 
         Args:
-            localpath: string pointing to the data for which the filtering
+            localpath (string): pointing to the data for which the filtering
                 applies. If no other arguments, only realizations containing
                 this data key is kept.
-            key: A certain key within a realization dictionary that is
+            key (str): A certain key within a realization dictionary that is
                 required to be present. If a value is also provided, this
                 key must be equal to this value
-            value: The value a certain key must equal. Floating point
-                comparisons are not robust.
-            column: Name of a column in tabular data. If columncontains is
+            value (str, int or float): The value a certain key must equal. Floating
+                point comparisons are not robust.
+            column (str): Name of a column in tabular data. If columncontains is
                 not specified, this means that this column must be present
-            columncontains:
+            columncontains (str, int or float):
                 A value that the specific column must include.
-            inplace: Boolean indicating if the current object should have its
+            inplace (boolean): Indicating if the current object should have its
                 realizations stripped, or if a copy should be returned.
                 Default true.
 
@@ -777,7 +787,7 @@ class ScratchEnsemble(object):
 
         Returns:
             pd.DataFrame, aggregated result of the supplied function
-                on each realization.
+            on each realization.
         """
         results = []
         for realidx, realization in self._realizations.items():
@@ -975,10 +985,7 @@ class ScratchEnsemble(object):
             If quantiles are explicitly supplied, the 'pXX'
             strings in the outer index are changed accordingly. If no
             data is found, return empty DataFrame.
-
-        TODO: add warning message when failed realizations are removed
         """
-
         if quantiles is None:
             quantiles = [10, 90]
 

--- a/src/fmu/ensemble/ensemblecombination.py
+++ b/src/fmu/ensemble/ensemblecombination.py
@@ -8,8 +8,8 @@ from __future__ import print_function
 
 import pandas as pd
 
-from .etc import Interaction
 from fmu.ensemble.virtualensemble import VirtualEnsemble
+from .etc import Interaction
 
 xfmu = Interaction()
 logger = xfmu.functionlogger(__name__)

--- a/src/fmu/ensemble/ensembleset.py
+++ b/src/fmu/ensemble/ensembleset.py
@@ -77,9 +77,11 @@ class EnsembleSet(object):
             or (runpathfile and ensembles)
         ):
             logger.error(
-                "EnsembleSet only supports one initialization mode,"
-                + "from list of ensembles\n, list of paths or "
-                + "an ert runpath file"
+                (
+                    "EnsembleSet only supports one initialization mode,"
+                    "from list of ensembles\n, list of paths or "
+                    "an ert runpath file"
+                )
             )
             raise ValueError
 

--- a/src/fmu/ensemble/realization.py
+++ b/src/fmu/ensemble/realization.py
@@ -63,16 +63,16 @@ class ScratchRealization(object):
     Args:
         path (str): absolute or relative path to a directory
             containing a realizations files.
-        realidxregexp: a compiled regular expression which
+        realidxregexp (re/str): a compiled regular expression which
             is used to determine the realization index (integer)
             from the path. First match is the index.
             Default: realization-(\d+)
             Only needs to match path components.
             If a string is supplied, it will be attempted
             compiled into a regular expression.
-        index: int, the realization index to be used, will
+        index (int): the realization index to be used, will
             override anything else.
-        autodiscovery: boolean, whether the realization should try to
+        autodiscovery (boolean): whether the realization should try to
             auto-discover certain data (UNSMRY files in standard location)
     """
 
@@ -159,7 +159,7 @@ class ScratchRealization(object):
         """Return the runpath ("root") of the realization
 
         Returns:
-            str with a filesystem path which at least existeda
+            str: the filesystem path which at least existed
                 at time of object initialization.
         """
         return self._origpath
@@ -169,8 +169,8 @@ class ScratchRealization(object):
         to a VirtualRealization
 
         Args:
-            description: string, used as label
-            deepcopy: boolean. Set to true if you want to continue
+            description (str): used as label
+            deepcopy (boolean): Set to true if you want to continue
                to manipulate the ScratchRealization object
                afterwards without affecting the virtual realization.
                Defaults to True. False will give faster execution.
@@ -186,9 +186,9 @@ class ScratchRealization(object):
         Parse and internalize files from disk.
 
         Several file formats are supported:
-        * txt (one key-value pair pr. line)
-        * csv
-        * scalar (one number or one string in the first line)
+        - txt (one key-value pair pr. line)
+        - csv
+        - scalar (one number or one string in the first line)
         """
         if fformat == "txt":
             self.load_txt(localpath, convert_numeric, force_reread)
@@ -224,7 +224,7 @@ class ScratchRealization(object):
             convert_numeric: If True, non-numerical content will be thrown away
             force_reread: Reread the data from disk.
         Returns:
-            the value read from the file.
+            str/number: the value read from the file.
         """
         fullpath = os.path.abspath(os.path.join(self._origpath, localpath))
         if not os.path.exists(fullpath):
@@ -299,7 +299,7 @@ class ScratchRealization(object):
                 returned cached results.
 
         Returns:
-            dict with the parsed values. Values will be returned as
+            dict: Dictionary with the parsed values. Values will be returned as
                 integers, floats or strings. If convert_numeric
                 is False, all values are strings.
         """
@@ -507,9 +507,9 @@ class ScratchRealization(object):
         to disk using the supplied 'localpath'.
 
         Args:
-            **kwargs: dict which is supplied to the callbacked function,
-            in which the key 'localpath' also points the the name
-            used for data internalization.
+            **kwargs (dict): which is supplied to the callbacked function,
+                in which the key 'localpath' also points the the name
+                used for data internalization.
         """
 
         if not kwargs:
@@ -577,17 +577,19 @@ class ScratchRealization(object):
         or scalars.
 
         Shorthand is allowed, if the fully qualified localpath is
-            'share/results/volumes/simulator_volume_fipnum.csv'
+
+          'share/results/volumes/simulator_volume_fipnum.csv'
         then you can also get this dataframe returned with these alternatives:
-         * simulator_volume_fipnum
-         * simulator_volume_fipnum.csv
-         * share/results/volumes/simulator_volume_fipnum
+
+          * simulator_volume_fipnum
+          * simulator_volume_fipnum.csv
+          * share/results/volumes/simulator_volume_fipnum
 
         but only as long as there is no ambiguity. In case of ambiguity, a
         ValueError will be raised.
 
         Args:
-            localpath: the idenfier of the data requested
+            localpath (str): the idenfier of the data requested
 
         Returns:
             dataframe or dictionary
@@ -609,11 +611,13 @@ class ScratchRealization(object):
         within the datastore.
 
         If the fully qualified localpath is
-            'share/results/volumes/simulator_volume_fipnum.csv'
+
+          'share/results/volumes/simulator_volume_fipnum.csv'
         then you can also access this with these alternatives:
-         * simulator_volume_fipnum
-         * simulator_volume_fipnum.csv
-         * share/results/volumes/simulator_volume_fipnum
+
+          * simulator_volume_fipnum
+          * simulator_volume_fipnum.csv
+          * share/results/volumes/simulator_volume_fipnum
 
         but only as long as there is no ambiguity. In case
         of ambiguity, the shortpath will be returned.
@@ -714,8 +718,8 @@ class ScratchRealization(object):
                 files should be traversed
 
         Returns:
-           EclSum: object representing the summary file. None if
-               nothing was found.
+            EclSum: object representing the summary file. None if
+                nothing was found.
         """
         if cache and self._eclsum:  # Return cached object if available
             if self._eclsum_include_restart == include_restart:
@@ -810,7 +814,8 @@ class ScratchRealization(object):
             DataFrame with summary keys as columns and dates as indices.
                 Empty dataframe if no summary is available or column
                 keys do not exist.
-
+            DataFrame: with summary keys as columns and dates as indices.
+                Empty dataframe if no summary is available.
         """
         if not self.get_eclsum(cache=cache_eclsum):
             # Return empty, but do not store the empty dataframe in self.data

--- a/src/fmu/ensemble/realization.py
+++ b/src/fmu/ensemble/realization.py
@@ -405,6 +405,7 @@ class ScratchRealization(object):
             A dataframe with information from the STATUS files.
             Each row represents one job in one of the realizations.
         """
+
         statusfile = os.path.join(self._origpath, "STATUS")
         if not os.path.exists(statusfile):
             # This should not happen as long as __init__ requires STATUS
@@ -689,7 +690,7 @@ class ScratchRealization(object):
             columns=["FULLPATH", "FILETYPE", "LOCALPATH", "BASENAME"]
         )
         for searchpath in paths:
-            globs = glob.glob(os.path.join(self._origpath, searchpath))
+            globs = [f for f in glob.glob(os.path.join(self._origpath, searchpath)) if os.path.isfile(f)]
             for match in globs:
                 absmatch = os.path.abspath(match)
                 dirname = os.path.dirname(absmatch)

--- a/src/fmu/ensemble/realization.py
+++ b/src/fmu/ensemble/realization.py
@@ -17,11 +17,11 @@ import re
 import copy
 import glob
 import json
-import yaml
 from datetime import datetime, date, time
 import collections
 import dateutil
 
+import yaml
 import numpy
 import pandas as pd
 
@@ -1023,10 +1023,12 @@ class ScratchRealization(object):
                 is compatible with the date index and the cumulative data.
 
         """
-        return self._get_volumetric_rates(self, column_keys, time_index, time_unit)
+        return self.static_get_volumetric_rates(
+            self, column_keys, time_index, time_unit
+        )
 
     @staticmethod
-    def _get_volumetric_rates(realization, column_keys, time_index, time_unit):
+    def static_get_volumetric_rates(realization, column_keys, time_index, time_unit):
         """Static method for volumetric rates
 
         This method is to be used by both ScratchRealization
@@ -1558,18 +1560,18 @@ def normalize_dates(start_date, end_date, freq):
     return (start_date, end_date)
 
 
-def flatten(d, parent_key="", sep="_"):
+def flatten(dictionary, parent_key="", sep="_"):
     """Flatten dictionary keys
 
     Code from stackoverflow.
     """
     items = []
-    for k, v in d.items():
-        new_key = parent_key + sep + k if parent_key else k
-        if isinstance(v, collections.MutableMapping):
-            items.extend(flatten(v, new_key, sep=sep).items())
+    for key, value in dictionary.items():
+        new_key = parent_key + sep + key if parent_key else key
+        if isinstance(value, collections.MutableMapping):
+            items.extend(flatten(value, new_key, sep=sep).items())
         else:
-            items.append((new_key, v))
+            items.append((new_key, value))
     return dict(items)
 
 

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -633,16 +633,16 @@ file is picked up"""
                 else:
                     logger.debug("from_disk: Ignoring file: %s", filename)
 
-            if not lazy_load:
-                # Load all found dataframes from disk:
-                for internalizedkey, filename in self.lazy_frames.iteritems():
-                    self._load_frame_fromdisk(internalizedkey, filename)
-                self.lazy_frames = {}
+        if not lazy_load:
+            # Load all found dataframes from disk:
+            for internalizedkey, filename in self.lazy_frames.iteritems():
+                self._load_frame_fromdisk(internalizedkey, filename)
+            self.lazy_frames = {}
 
-            # This function must be called whenever we have done
-            # something manually with the dataframes, like adding realizations.
-            # IT MIGHT BE INCORRECT IF LAZY_LOAD...
-            self.update_realindices()
+        # This function must be called whenever we have done
+        # something manually with the dataframes, like adding realizations.
+        # IT MIGHT BE INCORRECT IF LAZY_LOAD...
+        self.update_realindices()
 
     def _load_frame_fromdisk(self, key, filename):
         if filename.endswith(".parquet"):

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -53,6 +53,8 @@ class VirtualEnsemble(object):
                 "Can't initialize from both data and " + "disk at the same time"
             )
 
+        self.realindices = []
+
         # At ensemble level, this dictionary has dataframes only.
         # All dataframes have the column REAL.
         if data:
@@ -62,8 +64,6 @@ class VirtualEnsemble(object):
 
         if fromdisk:
             self.from_disk(fromdisk)
-
-        self.realindices = []
 
     def __len__(self):
         """Return the number of realizations (integer) included in the
@@ -634,6 +634,10 @@ file is picked up"""
                             self.data[internalizedkey] = parsedframe
                 else:
                     logger.debug("from_disk: Ignoring file: %s", filename)
+
+            # This function must be called whenever we have done
+            # something manually with the dataframes, like adding realizations.
+            self.update_realindices()
 
     def __repr__(self):
         """Textual representation of the object"""

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -595,6 +595,10 @@ file is picked up"""
         self._name = None
 
         for root, _, filenames in os.walk(filesystempath):
+            if "__discoveredfiles" in root:
+                # Never traverse the collections of dumped
+                # discovered files
+                continue
             localpath = root.replace(filesystempath, "")
             if localpath and localpath[0] == os.path.sep:
                 localpath = localpath[1:]

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -8,6 +8,8 @@ from __future__ import print_function
 import os
 import re
 import shutil
+import datetime
+
 import numpy as np
 import pandas as pd
 
@@ -583,6 +585,7 @@ file is picked up"""
             lazy_load (bool): If True, loading of dataframes from disk
                 will be postponed until get_df() is actually called.
         """
+        start_time = datetime.datetime.now()
         if fmt not in ["csv", "parquet"]:
             raise ValueError("Unknown format for from_disk: %s" % fmt)
 
@@ -649,6 +652,14 @@ file is picked up"""
         # something manually with the dataframes, like adding realizations.
         # IT MIGHT BE INCORRECT IF LAZY_LOAD...
         self.update_realindices()
+
+        end_time = datetime.datetime.now()
+        if lazy_load:
+            lazy_str = "(lazy) "
+        else:
+            lazy_str = ""
+        logger.info("Loading ensemble from disk %stook %g seconds", lazy_str, (end_time - start_time).total_seconds())
+
 
     def _load_frame_fromdisk(self, key, filename):
         if filename.endswith(".parquet"):
@@ -904,9 +915,8 @@ file is picked up"""
 
         Return:
             pd.Dataframe. Empty if no files are meaningful"""
-        if "__files" in self.data:
-            return self.data["__files"]
-        return pd.DataFrame()
+        files = self.get_df('__files')
+        return files
 
     @property
     def parameters(self):

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -104,7 +104,7 @@ class VirtualEnsemble(object):
         resemble the filenames from which they were originally
         loaded in a ScratchEnsemble.
         """
-        return self.data.keys() + self.lazy_frames.keys()
+        return list(self.data.keys()) + list(self.lazy_frames.keys())
 
     def lazy_keys(self):
         """Return keys that are not yet loaded, but will
@@ -702,7 +702,7 @@ file is picked up"""
             return self.data[localpath]
 
         # Allow shorthand, but check ambiguity
-        allkeys = self.data.keys() + self.lazy_frames.keys()
+        allkeys = list(self.data.keys()) + list(self.lazy_frames.keys())
         basenames = [os.path.basename(x) for x in allkeys]
         if basenames.count(localpath) == 1:
             shortcut2path = {os.path.basename(x): x for x in allkeys}

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -90,11 +90,12 @@ class VirtualEnsemble(object):
         within the datastore.
 
         If the fully qualified localpath is
+
             'share/results/volumes/simulator_volume_fipnum.csv'
         then you can also access this with these alternatives:
-         * simulator_volume_fipnum
-         * simulator_volume_fipnum.csv
-         * share/results/volumes/simulator_volume_fipnum
+          * simulator_volume_fipnum
+          * simulator_volume_fipnum.csv
+          * share/results/volumes/simulator_volume_fipnum
 
         but only as long as there is no ambiguity. In case
         of ambiguity, the shortpath will be returned.
@@ -370,11 +371,13 @@ class VirtualEnsemble(object):
         """Access the internal datastore which contains dataframes or dicts
 
         Shorthand is allowed, if the fully qualified localpath is
+
             'share/results/volumes/simulator_volume_fipnum.csv'
         then you can also get this dataframe returned with these alternatives:
-         * simulator_volume_fipnum
-         * simulator_volume_fipnum.csv
-         * share/results/volumes/simulator_volume_fipnum
+
+          * simulator_volume_fipnum
+          * simulator_volume_fipnum.csv
+          * share/results/volumes/simulator_volume_fipnum
 
         but only as long as there is no ambiguity. In case of ambiguity, a
         ValueError will be raised.

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -106,6 +106,12 @@ class VirtualEnsemble(object):
         """
         return self.data.keys() + self.lazy_frames.keys()
 
+    def lazy_keys(self):
+        """Return keys that are not yet loaded, but will
+        be loaded on demand"""
+        return list(self.lazy_frames.keys())
+
+
     def shortcut2path(self, shortpath):
         """
         Convert short pathnames to fully qualified pathnames

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -178,16 +178,18 @@ class VirtualEnsemble(object):
 
         # Add the data from the incoming realization key by key
         for key in realization.keys():
-            df = realization.get_df(key)
-            if isinstance(df, dict):  # dicts to go to one-row dataframes
-                df = pd.DataFrame(index=[1], data=df)
-            if isinstance(df, (str, int, float)):
-                df = pd.DataFrame(index=[1], columns=[key], data=df)
-            df["REAL"] = realidx
+            dframe = realization.get_df(key)
+            if isinstance(dframe, dict):  # dicts to go to one-row dataframes
+                dframe = pd.DataFrame(index=[1], data=dframe)
+            if isinstance(dframe, (str, int, float)):
+                dframe = pd.DataFrame(index=[1], columns=[key], data=dframe)
+            dframe["REAL"] = realidx
             if key not in self.data.keys():
-                self.data[key] = df
+                self.data[key] = dframe
             else:
-                self.data[key] = self.data[key].append(df, ignore_index=True, sort=True)
+                self.data[key] = self.data[key].append(
+                    dframe, ignore_index=True, sort=True
+                )
         self.update_realindices()
 
     def remove_realizations(self, deleteindices):

--- a/src/fmu/ensemble/virtualrealization.py
+++ b/src/fmu/ensemble/virtualrealization.py
@@ -76,6 +76,8 @@ class VirtualRealization(object):
             filesystempath : string with a directory, absolute or
                 relative. If it exists already, it must be empty,
                 otherwise we give up.
+            delete: boolean, if True, existing directory at the filesystempath
+                will be deleted before export.
         """
         if os.path.exists(filesystempath):
             if delete:

--- a/tests/test_azureensemble.py
+++ b/tests/test_azureensemble.py
@@ -51,8 +51,9 @@ def test_reek_5real():
 
     testdir = os.path.join(testrootdir, 'TMP', 'dumped_ens')
 
-    # delete existing data in the testdir
-    shutil.rmtree(testdir)
+    # delete existing data in the testdir if already there
+    if os.path.isdir(testdir):
+        shutil.rmtree(testdir)
 
 
     reekensemble = AzureScratchEnsemble('reektest', 

--- a/tests/test_azureensemble.py
+++ b/tests/test_azureensemble.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""Testing AzureScratchEnsemble"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from fmu.ensemble import AzureScratchEnsemble, etc
+
+fmux = etc.Interaction()
+logger = fmux.basiclogger(__name__, level="WARNING")
+
+if not fmux.testsetup():
+    raise SystemExit()
+
+def test_empty_ensemble():
+
+    # initialize an empty AzureScratchEnsemble
+    aens = AzureScratchEnsemble('MyEns', 
+                            ensemble_path=None, 
+                            iter_name=None, 
+                            manifest={'Some key' : 'Some value'}, 
+                            ignoredirs=None,
+                                            )
+
+    # test individual functions
+
+    subdirs = ['/one', '/one/two', '/one/three', '/two/one', '/three']
+    ignoredirs = ['one']
+
+    assert aens.remove_ignored_dirs(subdirs, ignoredirs) == ['/two/one', '/three']
+    assert aens.manifest == {'Some key' : 'Some value'}, aens.manifest
+

--- a/tests/test_azureensemble.py
+++ b/tests/test_azureensemble.py
@@ -49,6 +49,9 @@ def test_reek_5real():
     else:
         testrootdir = os.path.abspath(".")
 
+    if not os.path.isdir(os.path.join(testrootdir, 'TMP')):
+        os.path.mkdir(os.path.join(testrootdir, 'TMP'))
+
     testdir = os.path.join(testrootdir, 'TMP', 'dumped_ens')
 
     # delete existing data in the testdir if already there

--- a/tests/test_azureensemble.py
+++ b/tests/test_azureensemble.py
@@ -49,8 +49,10 @@ def test_reek_5real():
     else:
         testrootdir = os.path.abspath(".")
 
-    if not os.path.isdir(os.path.join(testrootdir, 'TMP')):
-        os.path.mkdir(os.path.join(testrootdir, 'TMP'))
+    try: 
+        os.mkdir(os.path.join(testrootdir, 'TMP')) 
+    except OSError as error: 
+        print(error)
 
     testdir = os.path.join(testrootdir, 'TMP', 'dumped_ens')
 

--- a/tests/test_azureensemble.py
+++ b/tests/test_azureensemble.py
@@ -5,13 +5,22 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from fmu.ensemble import AzureScratchEnsemble, etc
+from fmu.ensemble import AzureScratchEnsemble
+from fmu.ensemble import ScratchEnsemble, VirtualEnsemble, ScratchRealization
+from fmu.ensemble import etc
+
+import os
+import shutil
+import pandas as pd
+import yaml
 
 fmux = etc.Interaction()
 logger = fmux.basiclogger(__name__, level="WARNING")
 
 if not fmux.testsetup():
     raise SystemExit()
+
+
 
 def test_empty_ensemble():
 
@@ -31,3 +40,56 @@ def test_empty_ensemble():
     assert aens.remove_ignored_dirs(subdirs, ignoredirs) == ['/two/one', '/three']
     assert aens.manifest == {'Some key' : 'Some value'}, aens.manifest
 
+
+def test_reek_5real():
+
+    if "__file__" in globals():
+        # Easen up copying test code into interactive sessions
+        testrootdir = os.path.dirname(os.path.abspath(__file__))
+    else:
+        testrootdir = os.path.abspath(".")
+
+    testdir = os.path.join(testrootdir, 'TMP', 'dumped_ens')
+
+    # delete existing data in the testdir
+    shutil.rmtree(testdir)
+
+
+    reekensemble = AzureScratchEnsemble('reektest', 
+            ensemble_path = os.path.join(testrootdir, 'data/testensemble-reek001/'),
+            iter_name = 'iter-0',
+            manifest = {'Reek has no' : 'manifest'},
+            ignoredirs = None,
+        )
+
+    # check that what is being passed on to ScratchEnsemble and VirtualEnsemble makes sense
+    assert isinstance(reekensemble, AzureScratchEnsemble)
+    assert isinstance(reekensemble.scratchensemble, ScratchEnsemble)
+    assert isinstance(reekensemble.virtualensemble, VirtualEnsemble)
+    assert isinstance(reekensemble.scratchensemble[0], ScratchRealization)
+    assert reekensemble.name == 'reektest'
+    assert len(reekensemble.scratchensemble) == 5
+    assert len(reekensemble) == 5
+
+
+    reekensemble.upload(testdir)
+
+    # check that some known files are present in the dumped data
+    assert os.path.isfile(os.path.join(testdir, 'data/share/smry.csv'))
+    assert os.path.isfile(os.path.join(testdir, 'data/share/OK.csv'))
+    assert os.path.isfile(os.path.join(testdir, 'data/realization-4/parameters.txt'))
+
+    # index
+    indexdf = pd.read_csv(os.path.join(testdir, 'index/index.csv'))
+    assert sorted(list(indexdf['REAL'].fillna(-999).unique())) == [-999,0,1,2,3,4]
+
+    # check that some known files are present in the index
+    assert 'data/share/smry.csv' in list(indexdf['LOCALPATH'])
+
+    # check that the manifest looks right
+    with open(os.path.join(testdir, 'manifest/manifest.yml'), 'r') as stream:
+            manifest = yaml.load(stream, Loader=yaml.FullLoader)
+
+    assert 'Reek has no' in manifest.keys()
+    assert 'rmrc' in manifest.keys()
+    assert manifest.get('rmrc').get('name') == 'reektest'

--- a/tests/test_ensemblecombination.py
+++ b/tests/test_ensemblecombination.py
@@ -114,11 +114,11 @@ def test_ensemblecombination_sparse():
     assert 3 not in (ior - ref)["unsmry--yearly"].REAL.unique()
 
     # Delete a specific date in the ior ensemble
-    df = ior[4].data["share/results/tables/unsmry--yearly.csv"]
-    print(df.DATE.dtype)
-    df.drop(2, inplace=True)  # index 2 is for date 2002-01-1
+    dframe = ior[4].data["share/results/tables/unsmry--yearly.csv"]
+    print(dframe.DATE.dtype)
+    dframe.drop(2, inplace=True)  # index 2 is for date 2002-01-1
     # Inject into ensemble again:
-    ior[4].data["share/results/tables/unsmry--yearly.csv"] = df
+    ior[4].data["share/results/tables/unsmry--yearly.csv"] = dframe
     assert "2002-01-01" not in list((ior - ref)["unsmry--yearly.csv"].DATE.unique())
 
     # Convert ref case to virtual:

--- a/tests/test_ensembleset.py
+++ b/tests/test_ensembleset.py
@@ -17,10 +17,10 @@ from fmu.ensemble import etc
 from fmu.ensemble import ScratchEnsemble, EnsembleSet
 
 try:
-    skip_fmu_tools = False
+    SKIP_FMU_TOOLS = False
     from fmu.tools import volumetrics
 except ImportError:
-    skip_fmu_tools = True
+    SKIP_FMU_TOOLS = True
 
 fmux = etc.Interaction()
 logger = fmux.basiclogger(__name__, level="WARNING")
@@ -120,7 +120,7 @@ def test_ensembleset_reek001(tmp="TMP"):
     # Eclipse well names
     assert len(ensset3.get_wellnames("OP*")) == 5
     assert len(ensset3.get_wellnames("WI*")) == 3
-    assert len(ensset3.get_wellnames("")) == 0
+    assert not ensset3.get_wellnames("")
     assert len(ensset3.get_wellnames()) == 8
 
     # Check that we can retrieve cached versions
@@ -154,7 +154,7 @@ def test_ensembleset_reek001(tmp="TMP"):
     assert len(ensset3.get_wellnames("OP*")) == 5
     assert len(ensset3.get_wellnames(None)) == 8
     assert len(ensset3.get_wellnames()) == 8
-    assert len(ensset3.get_wellnames("")) == 0
+    assert not ensset3.get_wellnames("")
     assert len(ensset3.get_wellnames(["OP*", "WI*"])) == 8
 
     # Test aggregation of csv files:
@@ -192,7 +192,7 @@ def test_ensembleset_reek001(tmp="TMP"):
         else:
             return pd.DataFrame()
 
-    if not skip_fmu_tools:
+    if not SKIP_FMU_TOOLS:
         rmsvols_df = ensset3.apply(
             rms_vol2df, filename="share/results/volumes/" + "geogrid_vol_oil_1.txt"
         )
@@ -225,7 +225,7 @@ def test_ensembleset_reek001(tmp="TMP"):
 
     # Delete the symlink and leftover from apply-testing when we are done.
     for real_dir in glob.glob(ensdir + "/realization-*"):
-        if not skip_fmu_tools:
+        if not SKIP_FMU_TOOLS:
             csvfile = real_dir + "/iter-0/share/results/volumes/geogrid--oil.csv"
             if os.path.exists(csvfile):
                 os.remove(csvfile)

--- a/tests/test_observations.py
+++ b/tests/test_observations.py
@@ -242,6 +242,7 @@ def test_errormessages():
 
     # Emtpy
     with pytest.raises(TypeError):
+        # pylint: disable=E1120
         Observations()
 
     # Non-existing filename:

--- a/tests/test_realizationcombination.py
+++ b/tests/test_realizationcombination.py
@@ -37,8 +37,9 @@ def test_realizationcombination_basic():
     real1 = ensemble.ScratchRealization(real1dir)
     real1.load_smry(time_index="yearly", column_keys=["F*"])
 
-    assert "FWPR" in ((real0 - real1)["unsmry--yearly"]).columns
-    assert "FWL" in ((real0 - real1)["parameters"])
+    realdiff = real0 - real1
+    assert "FWPR" in realdiff["unsmry--yearly"]
+    assert "FWL" in realdiff["parameters"]
 
 
 def test_manual_aggregation():

--- a/tests/test_rmrc.py
+++ b/tests/test_rmrc.py
@@ -55,7 +55,7 @@ def test_rmrc():
         "js_vens_dump", delete=True, dumpcsv=True, includefiles=True, symlinks=True
     )
     logger.info("Loading back from disk")
-    vens = VirtualEnsemble(fromdisk="js_vens_dump")
+    vens = VirtualEnsemble(fromdisk="js_vens_dump", lazy_load=True)
 
     logger.info("Doing asserts")
     assert not vens.files.empty

--- a/tests/test_rmrc.py
+++ b/tests/test_rmrc.py
@@ -38,7 +38,7 @@ def test_rmrc():
         "ens1", os.path.join(ens_path, "realization-*/{}".format(iteration_name))
     )
     logger.info("Loading smry")
-    # ens.load_smry(time_index="monthly")
+    ens.load_smry(time_index="yearly")
     logger.info("Finding *gri files")
     ens.find_files(
         "share/maps/depth/*.gri",

--- a/tests/test_rmrc.py
+++ b/tests/test_rmrc.py
@@ -6,10 +6,12 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import time
+import datetime
+
 import numpy as np
 import pandas as pd
 import pytest
-
 import xtgeo
 
 from fmu.ensemble import etc
@@ -55,7 +57,13 @@ def test_rmrc():
         "js_vens_dump", delete=True, dumpcsv=True, includefiles=True, symlinks=True
     )
     logger.info("Loading back from disk")
+    vens = VirtualEnsemble(fromdisk="js_vens_dump", lazy_load=False)
+    start_time = datetime.datetime.now()
     vens = VirtualEnsemble(fromdisk="js_vens_dump", lazy_load=True)
+    end_time = datetime.datetime.now()
+
+    # Lazy load must return in hopefully much less than 2 secs
+    assert (end_time - start_time).total_seconds() < 1.0
 
     logger.info("Doing asserts")
     assert not vens.files.empty

--- a/tests/test_rmrc.py
+++ b/tests/test_rmrc.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""Testing VirtualEnsembles for RMRC problems."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import numpy as np
+import pandas as pd
+import pytest
+
+import xtgeo
+
+from fmu.ensemble import etc
+from fmu.ensemble import ScratchEnsemble, VirtualEnsemble
+
+fmux = etc.Interaction()
+logger = fmux.basiclogger(__name__, level="INFO")
+
+if not fmux.testsetup():
+    raise SystemExit()
+
+
+def test_rmrc():
+    """Test the properties of a virtualized ScratchEnsemble on JS data"""
+
+    ens_path = "/scratch/johan_sverdrup2/peesv/2019a_b003p2p0_pred_102_9aug_ff_a/"
+    storage = "/scratch/johan_sverdrup2/rmrc/ens1/"
+    iteration_name = "pred"
+    local_paths = ["share/maps/depth", "share/maps/isochores"]
+
+    if not os.path.exists(ens_path):
+        pytest.skip("Test data not available")
+
+    logger.info("Constructing ensemble object from disk")
+    ens = ScratchEnsemble(
+        "ens1", os.path.join(ens_path, "realization-*/{}".format(iteration_name))
+    )
+    logger.info("Loading smry")
+    # ens.load_smry(time_index="monthly")
+    logger.info("Finding *gri files")
+    ens.find_files(
+        "share/maps/depth/*.gri",
+        metadata={"surfacetype": "depthsurface"},
+        metayaml=True,
+    )
+    ens.find_files(
+        "share/maps/isochores/*.gri",
+        metadata={"surfacetype": "isochores"},
+        metayaml=True,
+    )
+    logger.info("Dumping to disk (js_vens_dump)")
+    ens.to_virtual().to_disk(
+        "js_vens_dump", delete=True, dumpcsv=True, includefiles=True, symlinks=True
+    )
+    logger.info("Loading back from disk")
+    vens = VirtualEnsemble(fromdisk="js_vens_dump")
+
+    logger.info("Doing asserts")
+    assert not vens.files.empty
+
+    assert "surfacetype" in vens.files
+    assert set(vens.files["surfacetype"].dropna().unique()) == set(
+        ["depthsurface", "isochores"]
+    )
+
+    for _, surfacefilerow in vens.files[vens.files["FILETYPE"] == "gri"].iterrows():
+        assert os.path.exists(
+            "js_vens_dump/__discoveredfiles/realization-"
+            + str(surfacefilerow["REAL"])
+            + "/"
+            + surfacefilerow["LOCALPATH"]
+        )

--- a/tests/test_virtualensemble.py
+++ b/tests/test_virtualensemble.py
@@ -214,9 +214,19 @@ def test_todisk():
     # Here we could check filesystem equivalence if we want.
 
     vens.to_disk("vens_dumped_csv", delete=True, dumpparquet=False)
-    fromcsvdisk = VirtualEnsemble()
-    fromcsvdisk.from_disk("vens_dumped_csv")
+    fromcsvdisk = VirtualEnsemble(fromdisk="vens_dumped_csv")
+    lazyfromdisk = VirtualEnsemble(fromdisk="vens_dumped_csv", lazy_load=True)
     assert set(vens.keys()) == set(fromcsvdisk.keys())
+    assert set(vens.keys()) == set(lazyfromdisk.keys())
+    assert 'OK' in lazyfromdisk.lazy_frames.keys()
+    assert 'OK' not in lazyfromdisk.data.keys()
+    assert len(fromcsvdisk.get_df("OK")) == len(lazyfromdisk.get_df("OK"))
+    assert 'OK' not in lazyfromdisk.lazy_frames.keys()
+    assert 'OK' in lazyfromdisk.data.keys()
+    assert len(fromcsvdisk.parameters) == len(lazyfromdisk.parameters)
+    assert len(fromcsvdisk.get_df("unsmry--yearly")) == len(
+        lazyfromdisk.get_df("unsmry--yearly")
+    )
 
     vens.to_disk("vens_dumped_parquet", delete=True, dumpcsv=False)
     fromparquetdisk = VirtualEnsemble()

--- a/tests/test_virtualensemble.py
+++ b/tests/test_virtualensemble.py
@@ -175,8 +175,12 @@ def test_todisk():
     vens = reekensemble.to_virtual()
 
     vens.to_disk("vens_dumped", delete=True)
+    assert len(vens) == len(reekensemble)
 
     fromdisk = VirtualEnsemble(fromdisk="vens_dumped")
+
+    # Same number of realizations:
+    assert len(fromdisk) == len(vens)
 
     # Should have all the same keys,
     # but change of order is fine

--- a/tests/test_virtualensemble.py
+++ b/tests/test_virtualensemble.py
@@ -169,7 +169,7 @@ def test_get_smry_interpolation():
     # Create a vens that contains both monthly and yearly:
     vens_monthly = reekensemble.to_virtual()
     reekensemble.load_smry(time_index="daily", column_keys=["F*"])
-    vens_daily = reekensemble.to_virtual()  # monthly, yearly *and* daily
+    _ = reekensemble.to_virtual()  # monthly, yearly *and* daily
 
     # Resample yearly to monthly:
     monthly = vens_yearly.get_smry(column_keys="FOPT", time_index="monthly")

--- a/tests/test_virtualensemble.py
+++ b/tests/test_virtualensemble.py
@@ -6,11 +6,12 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import numpy as np
 import pandas as pd
 import pytest
 
 from fmu.ensemble import etc
-from fmu.ensemble import ScratchEnsemble
+from fmu.ensemble import ScratchEnsemble, VirtualEnsemble
 
 fmux = etc.Interaction()
 logger = fmux.basiclogger(__name__, level="WARNING")
@@ -38,6 +39,10 @@ def test_virtualensemble():
     # Check that we have data for 5 realizations
     assert len(vens["unsmry--yearly"]["REAL"].unique()) == 5
     assert len(vens["parameters.txt"]) == 5
+
+    # This is the dataframe of discovered files in the ScratchRealization
+    assert isinstance(vens["__files"], pd.DataFrame)
+    assert not vens["__files"].empty
 
     assert "REAL" in vens["STATUS"].columns
 
@@ -148,6 +153,105 @@ def test_virtualensemble():
 
     # Betterdata should be returned as a dictionary
     assert isinstance(vens.agg("min").get_df("betterdata"), dict)
+
+
+def test_todisk():
+    """Test that we can write VirtualEnsembles to the filesystem in a
+    retrievable manner"""
+    if "__file__" in globals():
+        # Easen up copying test code into interactive sessions
+        testdir = os.path.dirname(os.path.abspath(__file__))
+    else:
+        testdir = os.path.abspath(".")
+    reekensemble = ScratchEnsemble(
+        "reektest", testdir + "/data/testensemble-reek001/" + "realization-*/iter-0"
+    )
+
+    reekensemble.load_smry(time_index="monthly", column_keys="*")
+    reekensemble.load_smry(time_index="daily", column_keys="*")
+    reekensemble.load_smry(time_index="yearly", column_keys="F*")
+    reekensemble.load_scalar("npv.txt")
+    reekensemble.load_txt("outputs.txt")
+    vens = reekensemble.to_virtual()
+
+    vens.to_disk("vens_dumped", delete=True)
+
+    fromdisk = VirtualEnsemble(fromdisk="vens_dumped")
+
+    # Should have all the same keys,
+    # but change of order is fine
+    assert set(vens.keys()) == set(fromdisk.keys())
+
+    for frame in vens.keys():
+        if frame == "STATUS":
+            continue
+        # Columns that only contains NaN will not have their
+        # type preserved, this is too much to ask for, especially
+        # with CSV files. So we drop columns with NaN
+        virtframe = vens.get_df(frame).dropna("columns")
+        diskframe = fromdisk.get_df(frame).dropna("columns")
+
+        assert (virtframe.columns == diskframe.columns).all()
+
+        # It would be nice to be able to use pd.Dataframe.equals,
+        # but it is too strict, as columns with mixed type number/strings
+        # will easily be wrong.
+
+        for column in virtframe.columns:
+            if virtframe[column].dtype == object or diskframe[column].dtype == object:
+                # Ensure we only compare strings when working with object dtype
+                assert (
+                    virtframe[column].astype(str).equals(diskframe[column].astype(str))
+                )
+            else:
+                assert virtframe[column].equals(diskframe[column])
+
+    fromdisk.to_disk("vens_double_dumped", delete=True)
+    # Here we could check filesystem equivalence if we want.
+
+    vens.to_disk("vens_dumped_csv", delete=True, dumpparquet=False)
+    fromcsvdisk = VirtualEnsemble()
+    fromcsvdisk.from_disk("vens_dumped_csv")
+    assert set(vens.keys()) == set(fromcsvdisk.keys())
+
+    vens.to_disk("vens_dumped_parquet", delete=True, dumpcsv=False)
+    fromparquetdisk = VirtualEnsemble()
+    fromparquetdisk.from_disk("vens_dumped_parquet")
+    assert set(vens.keys()) == set(fromparquetdisk.keys())
+
+    fromparquetdisk2 = VirtualEnsemble()
+    fromparquetdisk2.from_disk("vens_dumped_parquet", fmt="csv")
+    # Here we will miss a lot of CSV files, because we only wrote parquet:
+    assert len(vens.keys()) > len(fromparquetdisk2.keys())
+
+    fromcsvdisk2 = VirtualEnsemble()
+    fromcsvdisk2.from_disk("vens_dumped_csv", fmt="parquet")
+    # But even if we only try to load parquet files, when CSV
+    # files are found without corresponding parquet, the CSV file
+    # will be read.
+    assert set(vens.keys()) == set(fromcsvdisk2.keys())
+
+    # Test manual intervention:
+    fooframe = pd.DataFrame(data=np.random.randn(3, 3), columns=["FOO", "BAR", "COM"])
+    fooframe.to_csv(os.path.join("vens_dumped", "share/results/tables/randomdata.csv"))
+    manualens = VirtualEnsemble(fromdisk="vens_dumped")
+    assert "share/results/tables/randomdata.csv" not in manualens.keys()
+
+    # Now with correct column header,
+    # but floating point data for realizations..
+    fooframe = pd.DataFrame(data=np.random.randn(3, 3), columns=["REAL", "BAR", "COM"])
+    fooframe.to_csv(os.path.join("vens_dumped", "share/results/tables/randomdata.csv"))
+    manualens = VirtualEnsemble(fromdisk="vens_dumped")
+    assert "share/results/tables/randomdata.csv" not in manualens.keys()
+
+    # Now with correct column header, and with integer data for REAL..
+    fooframe = pd.DataFrame(
+        data=np.random.randint(low=0, high=100, size=(3, 3)),
+        columns=["REAL", "BAR", "COM"],
+    )
+    fooframe.to_csv(os.path.join("vens_dumped", "share/results/tables/randomdata.csv"))
+    manualens = VirtualEnsemble(fromdisk="vens_dumped")
+    assert "share/results/tables/randomdata.csv" in manualens.keys()
 
 
 def test_get_smry_interpolation():

--- a/tests/test_virtualensemble.py
+++ b/tests/test_virtualensemble.py
@@ -40,6 +40,8 @@ def test_virtualensemble():
     assert len(vens["unsmry--yearly"]["REAL"].unique()) == 5
     assert len(vens["parameters.txt"]) == 5
 
+    assert not vens.lazy_keys()
+
     # This is the dataframe of discovered files in the ScratchRealization
     assert isinstance(vens["__files"], pd.DataFrame)
     assert not vens["__files"].empty
@@ -94,7 +96,8 @@ def test_virtualensemble():
 
     # Test virtrealization retrieval:
     vreal = vens.get_realization(2)
-    assert vreal.keys() == vens.keys()
+    assert len(vreal.keys()) == len(vens.keys())
+    assert set(vreal.keys()) == set(vens.keys())  # Order is not preserved
 
     # Test realization removal:
     vens.remove_realizations(3)

--- a/tests/test_virtualensemble.py
+++ b/tests/test_virtualensemble.py
@@ -254,6 +254,36 @@ def test_todisk():
     assert "share/results/tables/randomdata.csv" in manualens.keys()
 
 
+def test_todisk_includefile():
+    """Test that we can write VirtualEnsembles to the filesystem in a
+    retrievable manner with discovered files included"""
+    if "__file__" in globals():
+        # Easen up copying test code into interactive sessions
+        testdir = os.path.dirname(os.path.abspath(__file__))
+    else:
+        testdir = os.path.abspath(".")
+    reekensemble = ScratchEnsemble(
+        "reektest", testdir + "/data/testensemble-reek001/" + "realization-*/iter-0"
+    )
+
+    reekensemble.load_smry(time_index="monthly", column_keys="*")
+    reekensemble.load_smry(time_index="daily", column_keys="*")
+    reekensemble.load_smry(time_index="yearly", column_keys="F*")
+    reekensemble.load_scalar("npv.txt")
+    reekensemble.load_txt("outputs.txt")
+    vens = reekensemble.to_virtual()
+
+    vens.to_disk("vens_dumped_files", delete=True, includefiles=True, symlinks=True)
+    for real in [0, 1, 2, 4, 4]:
+        runpath = os.path.join(
+            "vens_dumped_files", "__discoveredfiles", "realization-" + str(real)
+        )
+        assert os.path.exists(runpath)
+        assert os.path.exists(
+            os.path.join(runpath, "eclipse/model/2_R001_REEK-" + str(real) + ".UNSMRY")
+        )
+
+
 def test_get_smry_interpolation():
     """Test the summary resampling code for virtual ensembles"""
 

--- a/tests/test_virtualrealization.py
+++ b/tests/test_virtualrealization.py
@@ -168,6 +168,9 @@ def test_get_smry():
     assert all(dvfopt.diff() >= 0)
     # Linear interpolation should give many unique values:
     assert len(dvfopt["FOPT"].unique()) == 1462
+    # Length is here 1462 while daily smry for the scratchrealization
+    # would give 1098 (one year less) - this is correct here
+    # since we only have yearly dates to interpolate from.
 
     dvfopr = vreal.get_smry(column_keys="FOPR", time_index="daily")
     # FOPR is bfill'ed and should not have many unique values:
@@ -215,15 +218,15 @@ def test_get_smry2():
     real.load_smry(time_index="raw", column_keys=["F*"])
     vreal = real.to_virtual()
 
-    assert len(
-        vreal.get_smry(column_keys="FOPR", time_index="daily")["FOPR"].unique()
-        == len(daily)
+    assert len(vreal.get_smry(column_keys="FOPR", time_index="daily")["FOPR"]) == len(
+        daily
     )
-    assert len(
-        vreal.get_smry(column_keys="FOPT", time_index="daily")["FOPT"].unique()
-        == len(daily)
+
+    assert len(vreal.get_smry(column_keys="FOPT", time_index="daily")["FOPT"]) == len(
+        daily
     )
-    daily_dt = vreal._get_smry_dates("daily")
+
+    daily_dt = vreal.get_smry_dates("daily")
     # If we now ask for daily, we probably pick from 'raw' as it is
     # internalized.
     daily2 = vreal.get_smry(column_keys=["FOPR", "FOPT"], time_index=daily_dt)
@@ -265,7 +268,7 @@ def test_get_smry_dates():
     # First test with no data:
     empty_vreal = ensemble.VirtualRealization()
     with pytest.raises(ValueError):
-        empty_vreal._get_smry_dates()
+        empty_vreal.get_smry_dates()
 
     if "__file__" in globals():
         # Easen up copying test code into interactive sessions
@@ -278,12 +281,12 @@ def test_get_smry_dates():
     real.load_smry(time_index="yearly", column_keys=["F*", "W*"])
     vreal = real.to_virtual()
 
-    assert len(vreal._get_smry_dates(freq="monthly")) == 49
-    assert len(vreal._get_smry_dates(freq="daily")) == 1462
-    assert len(vreal._get_smry_dates(freq="yearly")) == 5
+    assert len(vreal.get_smry_dates(freq="monthly")) == 49
+    assert len(vreal.get_smry_dates(freq="daily")) == 1462
+    assert len(vreal.get_smry_dates(freq="yearly")) == 5
 
     with pytest.raises(ValueError):
-        assert vreal._get_smry_dates(freq="foobar")
+        assert vreal.get_smry_dates(freq="foobar")
 
 
 def test_volumetric_rates():


### PR DESCRIPTION
A separate module for all Azure-related things. Names of things can be discussed, but this is the logic behind:
- azureensemble has "azure" in it's name to compartmentalize things related specifically to Azure. This is not important now, but may become important when upload is added.
- AzureScratchEnsemble is essentially a wrapper for ScratchEnsemble, specifically made for (upload to) Azure.

The main idea is to separate out rmrc-functionality as much as possible to avoid messing with the existing API/functionality of fmu-ensemble. Some things might make sense to put in/move to existing classes at some point. But, it is also a point to compartmentalize this as much as possible. If something changes on the cloud-side, fmu-ensemble can then easily be updated without affecting existing usage.

The module is initialized with a slightly different API than e.g. ScratchEnsemble. It then uses ScratchEnsemble and VirtualEnsemble. It dumps collected files to disk, in same structure and format as they will have in the blobstore, ready for upload.

Todo:
- [x] Replace/append tmp_storage_path argument with random generator on /tmp disk
- [x] Support pre-compiled file indexes per realisation
- [x] Dump internal dataframes to .csv format
- [ ] Add actual uploading, including authentication and verification
- [ ] Explore uploading directly from where ERT dumped files (symlinks, or just through the index)

Builds on rmrc3-branch, so lots of commits from that branch is included here.
For now, quite some overlap with existing functionality in ScratchEnsemble and ScratchRealization. Kept like this for now, then align when we converge on something.

The index is currently still a dataframe, built based on VirtualEnsemble.files. The 'REAL' column changed from Int to Float when datatype when files that do not belong to any realization is added.