### PR TITLE
Manifest support

### DIFF
--- a/src/fmu/ensemble/ensemble.py
+++ b/src/fmu/ensemble/ensemble.py
@@ -353,7 +353,7 @@ class ScratchEnsemble(object):
         Args:
             name (str): Name of the ensemble as virtualized.
         """
-        vens = VirtualEnsemble(name=name)
+        vens = VirtualEnsemble(name=name, manifest=self.manifest)
 
         for key in self.keys():
             vens.append(key, self.get_df(key))

--- a/src/fmu/ensemble/ensemble.py
+++ b/src/fmu/ensemble/ensemble.py
@@ -14,6 +14,7 @@ from datetime import datetime
 import six
 import pandas as pd
 import numpy as np
+import yaml
 from ecl import EclDataType
 from ecl.eclfile import EclKW
 
@@ -70,6 +71,8 @@ class ScratchEnsemble(object):
         autodiscovery (boolean): True by default, means that the class
             can try to autodiscover data in the realization. Turn
             off to gain more fined tuned control.
+        manifest: dict or filename to use for manifest. If filename,
+            it must be a yaml-file that will be parsed to a single dict.
     """
 
     def __init__(
@@ -80,14 +83,18 @@ class ScratchEnsemble(object):
         runpathfile=None,
         runpathfilter=None,
         autodiscovery=True,
+        manifest=None,
     ):
         self._name = ensemble_name  # ensemble name
         self._realizations = {}  # dict of ScratchRealization objects,
         # indexed by realization indices as integers.
         self._ens_df = pd.DataFrame()
+        self._manifest = {}
+
         self._global_active = None
         self._global_size = None
         self._global_grid = None
+
         self.obs = None
 
         if isinstance(paths, str):
@@ -129,6 +136,10 @@ class ScratchEnsemble(object):
             count = self.add_from_runpathfile(runpathfile, runpathfilter)
         if isinstance(runpathfile, pd.DataFrame) and not runpathfile.empty:
             count = self.add_from_runpathfile(runpathfile, runpathfilter)
+
+        if manifest:
+            # The _manifest variable is set using a property decorator
+            self.manifest = manifest
 
         if count:
             logger.info("ScratchEnsemble initialized with %d realizations", count)
@@ -348,6 +359,32 @@ class ScratchEnsemble(object):
             vens.append(key, self.get_df(key))
         vens.update_realindices()
         return vens
+
+    @property
+    def manifest(self):
+        return self._manifest
+
+    @manifest.setter
+    def manifest(self, manifest):
+        if isinstance(manifest, dict):
+            if not manifest:
+                logger.warning("Empty manifest")
+                self._manifest = {}
+            else:
+                self._manifest = manifest
+        elif isinstance(manifest, six.string_types):
+            if os.path.exists(manifest):
+                manifest_fromyaml = yaml.safe_load(open(manifest))
+                if not manifest_fromyaml:
+                    logger.warning("Empty manifest")
+                    self._manifest = {}
+                else:
+                    self._manifest = manifest_fromyaml
+            else:
+                logger.error("Manifest file %s not found", manifest)
+        else:
+            # NoneType will also end here.
+            logger.error("Wrong manifest type supplied")
 
     @property
     def parameters(self):

--- a/src/fmu/ensemble/ensemble.py
+++ b/src/fmu/ensemble/ensemble.py
@@ -362,10 +362,25 @@ class ScratchEnsemble(object):
 
     @property
     def manifest(self):
+        """Get the manifest of the ensemble. The manifest is
+        nothing but a Python dictionary with unspecified content
+
+        Returns:
+            dict
+        """
         return self._manifest
 
     @manifest.setter
     def manifest(self, manifest):
+        """Set the manifest of the ensemble. The manifest
+        is nothing but a Python dictionary with unspecified
+        content
+
+        Args:
+            manifest: dict or str. If dict, it is used as is, if str it
+                is assumed to be a filename with YAML syntax which is
+                parsed into a dict and stored as dict
+        """
         if isinstance(manifest, dict):
             if not manifest:
                 logger.warning("Empty manifest")

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -601,6 +601,12 @@ class VirtualEnsemble(object):
 
     @property
     def manifest(self):
+        """Get the manifest of the ensemble. The manifest
+        is nothing but a dictionary with unspecified content
+
+        Returns:
+            dict
+        """
         return self._manifest
 
     @property

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -34,15 +34,23 @@ class VirtualEnsemble(object):
         name: string, can be chosen freely
         data: dict with data to initialize with. Defaults to empty
         longdescription: string, free form multiline description.
+        manifest: dict with any information about the ensemble
     """
 
-    def __init__(self, name=None, data=None, longdescription=None):
+    def __init__(self, name=None, data=None, longdescription=None, manifest=None):
         if name:
             self._name = name
         else:
             self._name = "VirtualEnsemble"
 
         self._longdescription = longdescription
+
+        if isinstance(manifest, dict):
+            self._manifest = manifest
+        else:
+            logger.warning(
+                "The manifest supplied to VirtualEnsemble " "must be of type dict"
+            )
 
         # At ensemble level, this dictionary has dataframes only.
         # All dataframes have the column REAL.
@@ -590,6 +598,10 @@ class VirtualEnsemble(object):
             vol_rate_df["REAL"] = realidx
             vol_rates_dfs.append(vol_rate_df)
         return pd.concat(vol_rates_dfs, ignore_index=True, sort=False)
+
+    @property
+    def manifest(self):
+        return self._manifest
 
     @property
     def parameters(self):

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 import os
 import shutil
 
+import yaml
 import numpy
 import pandas as pd
 
@@ -902,3 +903,66 @@ def test_apply():
     )
     assert rmsvols_df["STOIIP_OIL"].sum() > 0
     assert len(rmsvols_df["REAL"].unique()) == 4
+
+
+def test_manifest(tmpdir):
+    """Test import of a stripped 5 realization ensemble"""
+
+    if "__file__" in globals():
+        # Easen up copying test code into interactive sessions
+        testdir = os.path.dirname(os.path.abspath(__file__))
+    else:
+        testdir = os.path.abspath(".")
+
+    # Make a dummy manifest:
+    manifest = {
+        "description": "Demo ensemble for testing of fmu-ensemble",
+        "project_id": "Foobar",
+        "coordinate_system": "somethingfunny",
+    }
+
+    # Initialize with a ready made manifest dict:
+    ens = ScratchEnsemble(
+        "reektest",
+        testdir + "/data/testensemble-reek001/" + "realization-*/iter-0",
+        manifest=manifest,
+    )
+    assert "project_id" in ens.manifest
+
+    # Initialize without, and add it later:
+    ens = ScratchEnsemble(
+        "reektest", testdir + "/data/testensemble-reek001/" + "realization-*/iter-0"
+    )
+    assert "coordinate_system" not in ens.manifest
+    ens.manifest = manifest
+    assert "coordinate_system" in ens.manifest
+
+    # Dump to random filename, and load from that file:
+    with open(str(tmpdir.join("foo.yml")), "w") as file_h:
+        file_h.write(yaml.dump(manifest))
+    ens = ScratchEnsemble(
+        "reektest",
+        testdir + "/data/testensemble-reek001/" + "realization-*/iter-0",
+        manifest=str(tmpdir.join("foo.yml")),
+    )
+    assert "description" in ens.manifest
+
+    # Load from non-existing file:
+    ens = ScratchEnsemble(
+        "reektest",
+        testdir + "/data/testensemble-reek001/" + "realization-*/iter-0",
+        manifest=str(tmpdir.join("foo-notexisting.yml")),
+    )
+    assert isinstance(ens.manifest, dict)
+    assert not ens.manifest  # (empty dictionary)
+
+    # Load from empty file:
+    with open(str(tmpdir.join("empty")), "w") as file_h:
+        file_h.write("")
+
+    ens = ScratchEnsemble(
+        "reektest",
+        testdir + "/data/testensemble-reek001/" + "realization-*/iter-0",
+        manifest=str(tmpdir.join("empty")),
+    )
+    assert not ens.manifest

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -906,7 +906,7 @@ def test_apply():
 
 
 def test_manifest(tmpdir):
-    """Test import of a stripped 5 realization ensemble"""
+    """Test initializing ensembles with manifest """
 
     if "__file__" in globals():
         # Easen up copying test code into interactive sessions
@@ -928,6 +928,9 @@ def test_manifest(tmpdir):
         manifest=manifest,
     )
     assert "project_id" in ens.manifest
+
+    vens = ens.to_virtual()
+    assert "project_id" in vens.manifest
 
     # Initialize without, and add it later:
     ens = ScratchEnsemble(
@@ -955,6 +958,8 @@ def test_manifest(tmpdir):
     )
     assert isinstance(ens.manifest, dict)
     assert not ens.manifest  # (empty dictionary)
+    vens = ens.to_virtual()
+    assert not vens.manifest
 
     # Load from empty file:
     with open(str(tmpdir.join("empty")), "w") as file_h:


### PR DESCRIPTION
Solving (partially) #53 

This PR adds support for a manifest dictionary tied to a Scratch/VirtualEnsemble.

The to/from_disk functionality is put into the `vens_disk` branch.