### PR TITLE
Rm libecl from requirements in order to solve other problems

### DIFF
--- a/.github/workflows/fmu-ensemble.yml
+++ b/.github/workflows/fmu-ensemble.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Install fmu-ensemble with dependencies
         run: |
           pip install --upgrade pip
+          pip install libecl
           pip install .
 
       - name: Install test dependencies

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 REQUIREMENTS = [
-    "libecl",
+    # "libecl",   # Temporarily removed from requirements to solve problems elsewhere
     "numpy",
     "pandas>0.23.0",
     "pyyaml>=5.1",


### PR DESCRIPTION
libecl is still required in order to run, do a manual pip install for now.