### PR TITLE
time_index raw and None in load_smry + improved time_index verification

### DIFF
--- a/src/fmu/ensemble/ensemble.py
+++ b/src/fmu/ensemble/ensemble.py
@@ -771,8 +771,10 @@ class ScratchEnsemble(object):
                 end_date=end_date,
                 include_restart=include_restart,
             )
-        if isinstance(time_index, list):
+        if isinstance(time_index, (list, np.ndarray)):
             time_index = "custom"
+        elif time_index is None:
+            time_index = "raw"
         return self.get_df("share/results/tables/unsmry--" + time_index + ".csv")
 
     def get_volumetric_rates(self, column_keys=None, time_index=None):

--- a/src/fmu/ensemble/ensembleset.py
+++ b/src/fmu/ensemble/ensembleset.py
@@ -7,6 +7,8 @@ from __future__ import print_function
 import re
 import os
 import glob
+
+import numpy as np
 import pandas as pd
 
 from .etc import Interaction
@@ -551,7 +553,7 @@ class EnsembleSet(object):
 
     def load_smry(
         self,
-        time_index=None,
+        time_index="raw",
         column_keys=None,
         cache_eclsum=True,
         start_date=None,
@@ -573,7 +575,7 @@ class EnsembleSet(object):
 
         Args:
             time_index: list of DateTime if interpolation is wanted
-               default is None, which returns the raw Eclipse report times
+               default is raw, which returns the raw Eclipse report times
                If a string is supplied, that string is attempted used
                via get_smry_dates() in order to obtain a time index.
             column_keys: list of column key wildcards
@@ -602,8 +604,10 @@ class EnsembleSet(object):
                 start_date=start_date,
                 end_date=end_date,
             )
-        if isinstance(time_index, list):
+        if isinstance(time_index, (list, np.ndarray)):
             time_index = "custom"
+        elif time_index is None:
+            time_index = "raw"
         return self.get_df("share/results/tables/unsmry--" + time_index + ".csv")
 
     def get_smry(

--- a/src/fmu/ensemble/realization.py
+++ b/src/fmu/ensemble/realization.py
@@ -1055,9 +1055,14 @@ class ScratchRealization(object):
                 end_date=end_date,
                 include_restart=include_restart,
             )
-        if isinstance(time_index, list):
+        elif isinstance(time_index, (list, np.ndarray)):
             time_index_arg = time_index
             time_index_path = "custom"
+        elif time_index is None:
+            time_index_path = "raw"
+            time_index_arg = time_index
+        else:
+            raise TypeError("'time_index' has to be a string, a list or None")
 
         if not isinstance(column_keys, list):
             column_keys = [column_keys]
@@ -1131,9 +1136,10 @@ class ScratchRealization(object):
                     end_date=end_date,
                     include_restart=include_restart,
                 )
-        else:
+        elif time_index is None or isinstance(time_index, (list, np.ndarray)):
             time_index_arg = time_index
-
+        else:
+            raise TypeError("'time_index' has to be a string, a list or None")
         if self.get_eclsum(cache=cache_eclsum, include_restart=include_restart):
             try:
                 dataframe = self.get_eclsum(

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -815,13 +815,15 @@ file is picked up"""
             for x in self.keys()
             if "unsmry" in x
         ]
-
+        # If time_index is None, load_smry in ScratchEnsemble stores as "raw"
+        if time_index is None:
+            time_index = "raw"
         if (
             isinstance(time_index, str) and time_index not in available_smry
-        ) or isinstance(time_index, list):
+        ) or isinstance(time_index, (list, np.ndarray)):
             # Suboptimal code, we always pick the finest available
             # time resolution:
-            priorities = ["raw", "daily", "monthly", "weekly", "yearly", "custom"]
+            priorities = ["raw", "daily", "weekly", "monthly", "yearly", "custom"]
             # (could also sort them by number of rows, or we could
             #  even merge them all)
             # (could have priorities as a dict, for example so we

--- a/src/fmu/ensemble/virtualrealization.py
+++ b/src/fmu/ensemble/virtualrealization.py
@@ -340,7 +340,7 @@ class VirtualRealization(object):
         # calling function handle further errors.
         return shortpath
 
-    def get_smry(self, column_keys=None, time_index=None):
+    def get_smry(self, column_keys=None, time_index="monthly"):
         """Analog function to get_smry() in ScratchRealization
 
         Accesses the internalized summary data and performs
@@ -370,12 +370,13 @@ class VirtualRealization(object):
         if not column_keys:
             raise ValueError("No column keys found")
 
-        if not time_index:
-            time_index = "monthly"
+        # If time_index is None, load_smry in ScratchRealization stores as "raw"
+        if time_index is None:
+            time_index = "raw"
 
         if isinstance(time_index, str):
             time_index_dt = self.get_smry_dates(time_index)
-        elif isinstance(time_index, list):
+        elif isinstance(time_index, (list, np.ndarray)):
             time_index_dt = time_index
         else:
             raise TypeError
@@ -396,7 +397,7 @@ class VirtualRealization(object):
         ) or isinstance(time_index, list):
             # Suboptimal code, we always pick the finest available
             # time resolution:
-            priorities = ["raw", "daily", "monthly", "weekly", "yearly", "custom"]
+            priorities = ["raw", "daily", "weekly", "monthly", "yearly", "custom"]
             # (could also sort them by number of rows, or we could
             #  even merge them all)
             # (could have priorities as a dict, for example so we
@@ -495,6 +496,8 @@ class VirtualRealization(object):
             return [start_date.date()]
         if freq == "last":
             return [end_date.date()]
+        if freq in ("custom", "raw"):
+            return available_dates
         pd_freq_mnenomics = {"monthly": "MS", "yearly": "YS", "daily": "D"}
         if normalize:
             raise NotImplementedError

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -436,6 +436,15 @@ def test_ensemble_ecl():
     assert len(reekensemble.load_smry(column_keys=["FOPR"], time_index="last")) == 5
     assert isinstance(reekensemble.get_df("unsmry--last.csv"), pd.DataFrame)
 
+    # Check that time_index=None and time_index="raw" behaves like default
+    raw = reekensemble.load_smry(column_keys=["F*PT"], time_index="raw")
+    print(raw)
+    assert reekensemble.load_smry(column_keys=["F*PT"]).iloc[3, 2] == raw.iloc[3, 2]
+    assert (
+        reekensemble.load_smry(column_keys=["F*PT"], time_index=None).iloc[3, 3]
+        == raw.iloc[3, 3]
+    )
+
     # Give ISO-dates directly:
     assert (
         len(reekensemble.get_smry(column_keys=["FOPR"], time_index="2001-01-02")) == 5

--- a/tests/test_ensembleset.py
+++ b/tests/test_ensembleset.py
@@ -132,6 +132,12 @@ def test_ensembleset_reek001(tmpdir):
     assert monthly.columns[0] == "ENSEMBLE"
     assert monthly.columns[1] == "REAL"
     assert monthly.columns[2] == "DATE"
+    raw = ensset3.load_smry(column_keys=["F*PT"], time_index="raw")
+    assert ensset3.load_smry(column_keys=["F*PT"]).iloc[3, 4] == raw.iloc[3, 4]
+    assert (
+        ensset3.load_smry(column_keys=["F*PT"], time_index=None).iloc[3, 5]
+        == raw.iloc[3, 5]
+    )
 
     # Eclipse well names
     assert len(ensset3.get_wellnames("OP*")) == 5
@@ -192,7 +198,7 @@ def test_ensembleset_reek001(tmpdir):
     assert "ENSEMBLE" in vol_df
     assert len(vol_df["REAL"].unique()) == 3
     assert len(vol_df["ENSEMBLE"].unique()) == 2
-    assert len(ensset3.keys()) == 7
+    assert len(ensset3.keys()) == 8
 
     # Test scalar imports:
     ensset3.load_scalar("npv.txt")

--- a/tests/test_realization.py
+++ b/tests/test_realization.py
@@ -462,6 +462,8 @@ def test_datenormalization():
     testdir = os.path.dirname(os.path.abspath(__file__))
     realdir = os.path.join(testdir, "data/testensemble-reek001", "realization-0/iter-0")
     real = ensemble.ScratchRealization(realdir)
+    raw = real.get_smry(column_keys="FOPT", time_index="raw")
+    assert str(raw.index[-1]) == "2003-01-02 00:00:00"
     daily = real.get_smry(column_keys="FOPT", time_index="daily")
     assert str(daily.index[-1]) == "2003-01-02"
     monthly = real.get_smry(column_keys="FOPT", time_index="monthly")
@@ -469,14 +471,25 @@ def test_datenormalization():
     yearly = real.get_smry(column_keys="FOPT", time_index="yearly")
     assert str(yearly.index[-1]) == "2004-01-01"
 
+    # Check that time_index=None and time_index="raw" behaves like default
+    raw = real.load_smry(column_keys="FOPT", time_index="raw")
+    assert list(real.load_smry(column_keys="FOPT")["FOPT"].values) == list(
+        raw["FOPT"].values
+    )
+    assert list(
+        real.load_smry(column_keys="FOPT", time_index=None)["FOPT"].values
+    ) == list(raw["FOPT"].values)
+
     # Check that we get the same correct normalization
     # with load_smry()
+    real.load_smry(column_keys="FOPT", time_index="raw")
+    assert str(real.get_df("unsmry--raw")["DATE"].iloc[-1]) == "2003-01-02 00:00:00"
     real.load_smry(column_keys="FOPT", time_index="daily")
-    assert str(real.get_df("unsmry--daily")["DATE"].values[-1]) == "2003-01-02"
+    assert str(real.get_df("unsmry--daily")["DATE"].iloc[-1]) == "2003-01-02"
     real.load_smry(column_keys="FOPT", time_index="monthly")
-    assert str(real.get_df("unsmry--monthly")["DATE"].values[-1]) == "2003-02-01"
+    assert str(real.get_df("unsmry--monthly")["DATE"].iloc[-1]) == "2003-02-01"
     real.load_smry(column_keys="FOPT", time_index="yearly")
-    assert str(real.get_df("unsmry--yearly")["DATE"].values[-1]) == "2004-01-01"
+    assert str(real.get_df("unsmry--yearly")["DATE"].iloc[-1]) == "2004-01-01"
 
 
 def test_singlereal_ecl(tmp="TMP"):

--- a/tests/test_virtualrealization.py
+++ b/tests/test_virtualrealization.py
@@ -233,6 +233,7 @@ def test_get_smry2():
     real.load_smry(time_index="monthly", column_keys=["F*"])
     daily = real.load_smry(time_index="daily", column_keys=["F*"])
     real.load_smry(time_index="raw", column_keys=["F*"])
+    real.load_smry(time_index=None, column_keys=["F*"])
     vreal = real.to_virtual()
 
     assert len(vreal.get_smry(column_keys="FOPR", time_index="daily")["FOPR"]) == len(
@@ -241,6 +242,12 @@ def test_get_smry2():
 
     assert len(vreal.get_smry(column_keys="FOPT", time_index="daily")["FOPT"]) == len(
         daily
+    )
+
+    # Check that time_index=None and time_index='raw' are equal
+    pd.testing.assert_series_equal(
+        vreal.get_smry(time_index="raw")["FOPT"].reset_index(drop=True),
+        vreal.get_smry(time_index=None)["FOPT"].reset_index(drop=True),
     )
 
     daily_dt = vreal.get_smry_dates("daily")


### PR DESCRIPTION
Resolves #142 

**From issue**:
- Fixes issue with `time_index=None ` and `time_index="raw"` in `load_smry`.

- Default `time_index` in `load_smry` now consistent at `raw`.

- Improves verification of valid `time_index` in both `load_smry` and `get_smry` (checks type, also allows np.ndarray (array of datetimes) in addition to list).

- Included some tests + some modifications to existing tests.

**Additional changes:**
- Switched  order of `priorities` in `get_smry` for `weekly` and `monthly` as they were not in the order defined by the comment in the code (finest to coarsest available).

- Switched default `time_index` to `"monthly"` for `VirtualEnsemble` (same as in `VirtualRealization`, to preserve existing behavior for default. `time_index=None` will now equivalent `time_index="raw"` as in `get_smry` for the other classes.

