### PR TITLE
Use ecl2df for summary file extraction

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,9 +9,6 @@ exclude = docs,
 [aliases]
 test = pytest
 
-[tool:pytest]
-addopts = --verbose -x
-
 [build_sphinx]
 all-files = 1
 warning-is-error = 1

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ with open("HISTORY.rst", "rb") as history_file:
 
 REQUIREMENTS = [
     "ecl>=2.9",
+    "ecl2df",
     "numpy",
     "pandas",
     "pyyaml>=5.1",

--- a/src/fmu/ensemble/ensembleset.py
+++ b/src/fmu/ensemble/ensembleset.py
@@ -572,7 +572,6 @@ class EnsembleSet(object):
         self,
         time_index="raw",
         column_keys=None,
-        cache_eclsum=None,
         start_date=None,
         end_date=None,
     ):
@@ -596,9 +595,6 @@ class EnsembleSet(object):
                If a string is supplied, that string is attempted used
                via get_smry_dates() in order to obtain a time index.
             column_keys: list of column key wildcards
-            cache_eclsum: Boolean for whether we should cache the EclSum
-                objects. Set to False if you cannot keep all EclSum files in
-                memory simultaneously
             start_date: str or date with first date to include.
                 Dates prior to this date will be dropped, supplied
                 start_date will always be included. Overridden if time_index
@@ -612,21 +608,11 @@ class EnsembleSet(object):
             A DataFame of summary vectors for the ensembleset.
             The column 'ENSEMBLE' will denote each ensemble's name
         """
-        if cache_eclsum is not None:
-            warnings.warn(
-                (
-                    "cache_eclsum option to load_smry() is deprecated and "
-                    "will be removed in fmu-ensemble v2.0.0"
-                ),
-                FutureWarning,
-            )
-
         # Future: Multithread this:
         for _, ensemble in self._ensembles.items():
             ensemble.load_smry(
                 time_index=time_index,
                 column_keys=column_keys,
-                cache_eclsum=cache_eclsum,
                 start_date=start_date,
                 end_date=end_date,
             )
@@ -640,7 +626,6 @@ class EnsembleSet(object):
         self,
         time_index=None,
         column_keys=None,
-        cache_eclsum=None,
         start_date=None,
         end_date=None,
     ):
@@ -656,11 +641,6 @@ class EnsembleSet(object):
                If a string is supplied, that string is attempted used
                via get_smry_dates() in order to obtain a time index.
             column_keys: list of column key wildcards
-            cache_eclsum: boolean for whether to cache the EclSum
-                objects. Defaults to False. Set to True if
-                there is enough memory to keep all realizations summary
-                files in memory at once. This will speed up subsequent
-                operations
             start_date: str or date with first date to include.
                 Dates prior to this date will be dropped, supplied
                 start_date will always be included. Overridden if time_index
@@ -674,30 +654,16 @@ class EnsembleSet(object):
             ENSEMBLE will distinguish the different ensembles by their
             respective names.
         """
-
-        if cache_eclsum is not None:
-            warnings.warn(
-                (
-                    "cache_eclsum option to get_smry() is deprecated and "
-                    "will be removed in fmu-ensemble v2.0.0"
-                ),
-                FutureWarning,
-            )
-
         smrylist = []
         for _, ensemble in self._ensembles.items():
-            smry = ensemble.get_smry(
-                time_index, column_keys, cache_eclsum, start_date, end_date
-            )
+            smry = ensemble.get_smry(time_index, column_keys, start_date, end_date)
             smry.insert(0, "ENSEMBLE", ensemble.name)
             smrylist.append(smry)
         if smrylist:
             return pd.concat(smrylist, sort=False)
         return pd.DataFrame()
 
-    def get_smry_dates(
-        self, freq="monthly", cache_eclsum=None, start_date=None, end_date=None
-    ):
+    def get_smry_dates(self, freq="monthly", start_date=None, end_date=None):
         """Return list of datetimes from an ensembleset
 
         Datetimes from each realization in each ensemble can
@@ -709,9 +675,6 @@ class EnsembleSet(object):
                yield the sorted union of all valid timesteps for
                all realizations. Other valid options are
                'daily', 'monthly' and 'yearly'.
-            cache_eclsum: Boolean for whether we should cache the EclSum
-                objects. Set to False if you cannot keep all EclSum files in
-                memory simultaneously
             start_date: str or date with first date to include.
                 Dates prior to this date will be dropped, supplied
                 start_date will always be included. Overridden if time_index
@@ -723,22 +686,11 @@ class EnsembleSet(object):
         Returns:
             list of datetime.date.
         """
-
-        if cache_eclsum is not None:
-            warnings.warn(
-                (
-                    "cache_eclsum option to get_smry_dates() is deprecated and "
-                    "will be removed in fmu-ensemble v2.0.0"
-                ),
-                FutureWarning,
-            )
-
         rawdates = set()
         for _, ensemble in self._ensembles.items():
             rawdates = rawdates.union(
                 ensemble.get_smry_dates(
                     freq="report",
-                    cache_eclsum=cache_eclsum,
                     start_date=start_date,
                     end_date=end_date,
                 )

--- a/src/fmu/ensemble/observations.py
+++ b/src/fmu/ensemble/observations.py
@@ -1,6 +1,4 @@
-"""
-Observations support and related calculations
-"""
+"""Observations support and related calculations"""
 
 import os
 import math
@@ -174,7 +172,7 @@ class Observations(object):
         """
         dataseries = realization.get_smry(
             column_keys=[smryvector], time_index=time_index
-        )[smryvector]
+        )[["DATE", smryvector]].set_index("DATE")[smryvector]
 
         # In the context of this function, datetimes are not supported. Ensure dates:
         if isinstance(dataseries.index, pd.DatetimeIndex):

--- a/src/fmu/ensemble/realization.py
+++ b/src/fmu/ensemble/realization.py
@@ -26,19 +26,13 @@ from ecl.eclfile import EclFile
 from ecl.grid import EclGrid
 from ecl import EclFileFlagEnum
 
+import ecl2df
+
 from .virtualrealization import VirtualRealization
 from .realizationcombination import RealizationCombination
 from .util import parse_number, flatten, shortcut2path
 from .util.rates import compute_volumetric_rates
 from .util.dates import unionize_smry_dates
-
-HAVE_ECL2DF = False
-try:
-    import ecl2df
-
-    HAVE_ECL2DF = True
-except ImportError:
-    HAVE_ECL2DF = False
 
 logger = logging.getLogger(__name__)
 
@@ -105,8 +99,7 @@ class ScratchRealization(object):
         self.files = pd.DataFrame(
             columns=["FULLPATH", "FILETYPE", "LOCALPATH", "BASENAME"]
         )
-        self._eclsum = None  # Placeholder for caching
-        self._eclsum_include_restart = None  # Flag for cached object
+        self.eclfiles = None  # ecl2df.EclFiles object
 
         # The datastore for internalized data. Dictionary
         # indexed by filenames (local to the realization).
@@ -852,18 +845,21 @@ class ScratchRealization(object):
         Returns:
             ecl2df.EclFiles. None if nothing found
         """
-        if not HAVE_ECL2DF:
-            logger.warning("ecl2df not installed. Skipping")
-            return None
-        data_file_row = self.files[self.files["FILETYPE"] == "DATA"]
+        data_file_rows = self.files[self.files["FILETYPE"] == "DATA"]
         data_filename = None
-        if len(data_file_row) == 1:
-            data_filename = data_file_row["FULLPATH"].values[0]
+        unsmry_file_rows = self.files[self.files["FILETYPE"] == "UNSMRY"]
+        unsmry_filename = None
+        if len(data_file_rows) == 1:
+            data_filename = data_file_rows["FULLPATH"].values[0]
+        elif len(unsmry_file_rows) == 1:
+            unsmry_filename = unsmry_file_rows["FULLPATH"].values[0]
+            # We construct the DATA file, even though it might not exist:
+            data_filename = unsmry_filename.replace(".UNSMRY", ".DATA")
         elif self._autodiscovery:
             data_fileguess = os.path.join(self._origpath, "eclipse/model", "*.DATA")
             data_filenamelist = glob.glob(data_fileguess)
             if not data_filenamelist:
-                return None  # No filename matches *DATA
+                return None  # No filename matches *DATA or *UNSMRY
             if len(data_filenamelist) > 1:
                 logger.warning(
                     (
@@ -871,17 +867,32 @@ class ScratchRealization(object):
                         "consider turning off auto-discovery"
                     )
                 )
-            data_filename = data_filenamelist[0]
-            self.find_files(data_filename)
+            if data_filenamelist:
+                data_filename = data_filenamelist[0]
+                self.find_files(data_filename)
+
+            unsmry_fileguess = os.path.join(self._origpath, "eclipse/model", "*.UNSMRY")
+            unsmry_filenamelist = glob.glob(unsmry_fileguess)
+            if not unsmry_filenamelist:
+                return None  # No filename matches
+            if len(unsmry_filenamelist) > 1:
+                logger.warning(
+                    "Multiple UNSMRY files found, consider turning off auto-discovery"
+                )
+            unsmry_filename = unsmry_filenamelist[0]
+            self.find_files(unsmry_filename)
+
         else:
-            # There is no DATA file to be found.
-            logger.warning("No DATA file found!")
+            logger.warning("No DATA and/or UNSMRY file found!")
             return None
         if not os.path.exists(data_filename):
-            return None
+            if unsmry_filename is not None:
+                return ecl2df.EclFiles(unsmry_filename.replace(".UNSMRY", ".DATA"))
+            else:
+                return None
         return ecl2df.EclFiles(data_filename)
 
-    def get_eclsum(self, cache=True, include_restart=True):
+    def get_eclsum(self, include_restart=True):
         """
         Fetch the Eclipse Summary file from the realization
         and return as a libecl EclSum object
@@ -895,9 +906,6 @@ class ScratchRealization(object):
         turning off autodiscovery is strongly recommended.
 
         Arguments:
-            cache: boolean indicating whether we should keep an
-                object reference to the EclSum object. Set to
-                false if you need to conserve memory.
             include_restart: boolean sent to libecl for whether restart
                 files should be traversed.
 
@@ -905,10 +913,6 @@ class ScratchRealization(object):
             EclSum: object representing the summary file. None if
                 nothing was found.
         """
-        if cache and self._eclsum:  # Return cached object if available
-            if self._eclsum_include_restart == include_restart:
-                return self._eclsum
-
         unsmry_file_row = self.files[self.files.FILETYPE == "UNSMRY"]
         unsmry_filename = None
         if len(unsmry_file_row) == 1:
@@ -939,135 +943,51 @@ class ScratchRealization(object):
             # or if SMSPEC is missing.
             logger.warning("Failed to create summary instance from %s", unsmry_filename)
             return None
-
-        if cache:
-            self._eclsum = eclsum
-            self._eclsum_include_restart = include_restart
-
         return eclsum
 
-    def load_smry(
-        self,
-        time_index="raw",
-        column_keys=None,
-        cache_eclsum=None,
-        start_date=None,
-        end_date=None,
-        include_restart=True,
-    ):
-        """Produce dataframe from Summary data from the realization
+    def load_smry(self, **kwargs):
+        """Wrap around get_smry(), but also cache the result"""
+        dframe = self.get_smry(**kwargs)
 
-        When this function is called, the dataframe will be
-        internalized.  Internalization of summary data in a
-        realization object supports different time_index, but there is
-        no handling of multiple sets of column_keys. The cached data
-        will be called
+        cachename = None
+        # Cache the result for supported time indices:
+        if "time_index" not in kwargs or kwargs["time_index"] is None:
+            cachename = "raw"
+        elif isinstance(kwargs["time_index"], list):
+            cachename = "custom"
+        elif str(kwargs["time_index"]) in [
+            "raw",
+            "first",
+            "last",
+            "report",
+            "daily",
+            "weekly",
+            "monthly",
+            "yearly",
+        ]:
+            cachename = kwargs["time_index"]
 
-          'share/results/tables/unsmry--<time_index>.csv'
-
-        where <time_index> is among 'yearly', 'monthly', 'daily', 'first',
-        'last' or 'raw' (meaning the raw dates in the SMRY file), depending
-        on the chosen time_index. If a custom time_index (list
-        of datetime) was supplied, <time_index> will be called 'custom'.
-
-        Wraps ecl.summary.EclSum.pandas_frame()
-
-        See also get_smry()
-
-        Args:
-            time_index: string indicating a resampling frequency,
-               'yearly', 'monthly', 'daily', 'first', 'last' or 'raw', the
-               latter will return the simulated report steps (also default).
-               If a list of DateTime is supplied, data will be resampled
-               to these.
-            column_keys: list of column key wildcards. None means everything.
-            cache_eclsum: boolean for whether to keep the loaded EclSum
-                object in memory after data has been loaded.
-            start_date: str or date with first date to include.
-                Dates prior to this date will be dropped, supplied
-                start_date will always be included. Overridden if time_index
-                is 'first' or 'last'.
-            end_date: str or date with last date to be included.
-                Dates past this date will be dropped, supplied
-                end_date will always be included. Overridden if time_index
-                is 'first' or 'last'.
-            include_restart: boolean sent to libecl for whether restart
-                files should be traversed.
-
-        Returns:
-            DataFrame with summary keys as columns and dates as indices.
-                Empty dataframe if no summary is available or column
-                keys do not exist.
-            DataFrame: with summary keys as columns and dates as indices.
-                Empty dataframe if no summary is available.
-        """
-        if cache_eclsum is not None:
-            warnings.warn(
-                (
-                    "cache_eclsum option to load_smry() is deprecated and "
-                    "will be removed in fmu-ensemble v2.0.0"
-                ),
-                FutureWarning,
-            )
-        else:
-            cache_eclsum = True
-
-        if not self.get_eclsum(cache=cache_eclsum):
-            # Return empty, but do not store the empty dataframe in self.data
-            return pd.DataFrame()
-        time_index_path = time_index
-        if time_index == "raw":
-            time_index_arg = None
-        elif isinstance(time_index, str):
-            # Note: This call will recache the smry object.
-            time_index_arg = self.get_smry_dates(
-                freq=time_index,
-                start_date=start_date,
-                end_date=end_date,
-                include_restart=include_restart,
-            )
-        elif isinstance(time_index, (list, np.ndarray)):
-            time_index_arg = time_index
-            time_index_path = "custom"
-        elif time_index is None:
-            time_index_path = "raw"
-            time_index_arg = time_index
-        else:
-            raise TypeError("'time_index' has to be a string, a list or None")
-
-        if not isinstance(column_keys, list):
-            column_keys = [column_keys]
-
-        # Do the actual work:
-        dframe = self.get_eclsum(
-            cache=cache_eclsum, include_restart=include_restart
-        ).pandas_frame(time_index_arg, column_keys)
-        dframe = dframe.reset_index()
-        dframe.rename(columns={"index": "DATE"}, inplace=True)
-
-        # Cache the result:
-        localpath = "share/results/tables/unsmry--" + time_index_path + ".csv"
-        self.data[localpath] = dframe
-
-        # Do this to ensure that we cut the rope to the EclSum object
-        # Can be critical for garbage collection
-        if not cache_eclsum:
-            self._eclsum = None
+        if cachename:
+            localpath = "share/results/tables/unsmry--" + cachename + ".csv"
+            self.data[localpath] = dframe
         return dframe
 
     def get_smry(
         self,
         time_index=None,
         column_keys=None,
-        cache_eclsum=None,
         start_date=None,
         end_date=None,
         include_restart=True,
     ):
-        """Wrapper for EclSum.pandas_frame
+        """Wrapper for ecl2df.summary
 
         This gives access to the underlying data on disk without
         touching internalized dataframes.
+
+        The returned dataframe will have a dummy index, and the dates in
+        the column DATE. The DATE column will contain either datetime.datetime
+        or pandas.Timestamp objects.
 
         Arguments:
             time_index: string indicating a resampling frequency,
@@ -1077,8 +997,6 @@ class ScratchRealization(object):
                to these. If a date in ISO-8601 format is supplied, that is
                used as a single date.
             column_keys: list of column key wildcards. None means everything.
-            cache_eclsum: boolean for whether to keep the loaded EclSum
-                object in memory after data has been loaded.
             start_date: str or date with first date to include.
                 Dates prior to this date will be dropped, supplied
                 start_date will always be included. Overridden if time_index
@@ -1087,55 +1005,32 @@ class ScratchRealization(object):
                 Dates past this date will be dropped, supplied
                 end_date will always be included. Overridden if time_index
                 is 'first' or 'last'.
+            include_restart (bool): Whether to traverse restart files.
 
         Returns empty dataframe if there is no summary file, or if the
         column_keys are not existing.
         """
-
-        if cache_eclsum is not None:
-            warnings.warn(
-                (
-                    "cache_eclsum option to get_smry() is deprecated and "
-                    "will be removed in fmu-ensemble v2.0.0"
-                ),
-                FutureWarning,
-            )
-        else:
-            cache_eclsum = True
-
-        if not isinstance(column_keys, list):
-            column_keys = [column_keys]
-        if isinstance(time_index, str) and time_index == "raw":
-            time_index_arg = None
-        elif isinstance(time_index, str):
-            try:
-                parseddate = dateutil.parser.isoparse(time_index)
-                time_index_arg = [parseddate]
-            except ValueError:
-
-                time_index_arg = self.get_smry_dates(
-                    freq=time_index,
-                    start_date=start_date,
-                    end_date=end_date,
-                    include_restart=include_restart,
-                )
-        elif time_index is None or isinstance(time_index, (list, np.ndarray)):
-            time_index_arg = time_index
-        else:
-            raise TypeError("'time_index' has to be a string, a list or None")
-        if self.get_eclsum(cache=cache_eclsum, include_restart=include_restart):
-            try:
-                dataframe = self.get_eclsum(
-                    cache=cache_eclsum, include_restart=include_restart
-                ).pandas_frame(time_index_arg, column_keys)
-            except ValueError:
-                # We get here if we have requested non-existing column keys
-                return pd.DataFrame()
-            if not cache_eclsum:
-                # Ensure EclSum object can be garbage collected
-                self._eclsum = None
-            return dataframe
-        return pd.DataFrame()
+        if self.get_eclfiles() is None:
+            return pd.DataFrame()
+        try:
+            return ecl2df.summary.df(
+                self.get_eclfiles(),
+                time_index=time_index,
+                column_keys=column_keys,
+                start_date=start_date,
+                end_date=end_date,
+                include_restart=include_restart,
+                params=False,
+                paramfile=None,
+            ).reset_index()
+        except OSError:
+            # Missing or bogus UNSMRY file
+            return pd.DataFrame()
+        except ValueError:
+            # From libecl when requested columns keys are not found,
+            # or from pd.tseries.frequencies.to_offset() if frequency
+            # specifier is not known.
+            return pd.DataFrame()
 
     def get_smry_meta(self, column_keys=None):
         """
@@ -1195,7 +1090,7 @@ class ScratchRealization(object):
         keys = set()
         for key in column_keys:
             if isinstance(key, str):
-                keys = keys.union(set(self._eclsum.keys(key)))
+                keys = keys.union(set(self.get_eclsum().keys(key)))
         return list(keys)
 
     def get_volumetric_rates(self, column_keys=None, time_index=None, time_unit=None):
@@ -1224,25 +1119,19 @@ class ScratchRealization(object):
             ),
             FutureWarning,
         )
-
-        if not self._eclsum:  # check if it is cached
-            self.get_eclsum()
-
-        if not self._eclsum:
-            return pd.DataFrame()
-
         props = self._glob_smry_keys(props_wildcard)
 
-        if "numpy_vector" in dir(self._eclsum):
+        if "numpy_vector" in dir(self.get_eclsum()):
             data = {
-                prop: self._eclsum.numpy_vector(prop, report_only=False)
+                prop: self.get_eclsum().numpy_vector(prop, report_only=False)
                 for prop in props
             }
         else:  # get_values() is deprecated in newer libecl
             data = {
-                prop: self._eclsum.get_values(prop, report_only=False) for prop in props
+                prop: self.get_eclsum().get_values(prop, report_only=False)
+                for prop in props
             }
-        dates = self._eclsum.get_dates(report_only=False)
+        dates = self.get_eclsum().get_dates(report_only=False)
         return pd.DataFrame(data=data, index=dates)
 
     def get_smry_dates(

--- a/src/fmu/ensemble/realizationcombination.py
+++ b/src/fmu/ensemble/realizationcombination.py
@@ -149,6 +149,8 @@ class RealizationCombination(object):
             # Also delete columns where everything is NaN, happens when
             # column data are not similar
             result.dropna(axis="columns", how="all", inplace=True)
+            # Add metadata
+            result.attrs["meta"] = self.get_smry_meta()
             return result.reset_index()
         if isinstance(result, pd.Series):
             return result.dropna().to_dict()
@@ -240,7 +242,7 @@ class RealizationCombination(object):
             result = result.sub(otherdf)
         return result.reset_index()
 
-    def get_smry_meta(self, column_keys=None):
+    def get_smry_meta(self):
         """
         Provide metadata for summary data vectors.
 
@@ -253,15 +255,12 @@ class RealizationCombination(object):
         * get_num (int) (only provided if not None)
         * keyword (str)
         * wgname (str og None)
-
-        Args:
-            column_keys: List or str of column key wildcards
         """
-        meta = self.ref.get_smry_meta(column_keys=column_keys)
+        meta = self.ref.get_smry_meta()
         if self.add:
-            meta.update(self.add.get_smry_meta(column_keys=column_keys))
+            meta.update(self.add.get_smry_meta())
         if self.sub:
-            meta.update(self.sub.get_smry_meta(column_keys=column_keys))
+            meta.update(self.sub.get_smry_meta())
         return meta
 
     @property

--- a/src/fmu/ensemble/util/rates.py
+++ b/src/fmu/ensemble/util/rates.py
@@ -65,7 +65,9 @@ def compute_volumetric_rates(realization, column_keys, time_index, time_unit):
         return pd.DataFrame()
 
     cum_df = realization.get_smry(column_keys=column_keys, time_index=time_index)
-    # get_smry() for realizations return a dataframe indexed by 'DATE'
+
+    if not cum_df.empty:
+        cum_df.set_index("DATE", inplace=True)
 
     # Compute row-wise difference, shift back one row
     # to get the NaN to the end, and then drop the NaN.

--- a/src/fmu/ensemble/virtualensemble.py
+++ b/src/fmu/ensemble/virtualensemble.py
@@ -872,11 +872,6 @@ file is picked up"""
 
             # Now ask the VirtualRealization to do interpolation
             interp = vreal.get_smry(column_keys=column_keys, time_index=time_index)
-            # Assume we get back a dataframe indexed by the dates from vreal
-            # We must reset that index, and ensure the index column
-            # gets a correct name
-            interp.index = interp.index.set_names(["DATE"])
-            interp = interp.reset_index()
             interp["REAL"] = realidx
             smry_interpolated.append(interp)
         return pd.concat(smry_interpolated, ignore_index=True, sort=False)

--- a/tests/test_ecl2df.py
+++ b/tests/test_ecl2df.py
@@ -3,24 +3,15 @@
 import os
 import logging
 
-import pytest
+import ecl2df
 
 from fmu.ensemble import ScratchEnsemble, ScratchRealization
-
-HAVE_ECL2DF = True
-try:
-    import ecl2df
-except ImportError:
-    HAVE_ECL2DF = False
 
 logger = logging.getLogger(__name__)
 
 
 def test_ecl2df_real():
     """Check that we can utilize ecl2df on single realizations"""
-
-    if not HAVE_ECL2DF:
-        pytest.skip()
 
     if "__file__" in globals():
         # Easen up copying test code into interactive sessions
@@ -49,8 +40,6 @@ def test_reek():
     reekens = ScratchEnsemble(
         "reektest", testdir + "/data/testensemble-reek001/" + "realization-*/iter-0"
     )
-    if not HAVE_ECL2DF:
-        pytest.skip()
 
     def extract_compdat(kwargs):
         """Callback fnction to extract compdata data using ecl2df
@@ -90,8 +79,6 @@ def test_smry_via_ecl2df():
     reekens = ScratchEnsemble(
         "reektest", testdir + "/data/testensemble-reek001/" + "realization-*/iter-0"
     )
-    if not HAVE_ECL2DF:
-        pytest.skip()
 
     callback_smry = reekens.apply(get_smry, column_keys="FOPT", time_index="yearly")
     direct_smry = reekens.get_smry(column_keys="FOPT", time_index="yearly")

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -71,7 +71,6 @@ def test_reek001(tmpdir):
     paramsdf = reekensemble.parameters  # also test as property
     paramsdf = reekensemble.get_df("parameters.txt")
     assert len(paramsdf) == 5
-    print(paramsdf.head())
     assert len(paramsdf.columns) == 26  # 25 parameters, + REAL column
     paramsdf.to_csv("params.csv", index=False)
 
@@ -237,18 +236,6 @@ def test_emptyens():
     assert not emptygroups
 
     emptymeta = ens.get_smry_meta()
-    assert isinstance(emptymeta, dict)
-    assert not emptymeta
-
-    emptymeta = ens.get_smry_meta("*")
-    assert isinstance(emptymeta, dict)
-    assert not emptymeta
-
-    emptymeta = ens.get_smry_meta("FOPT")
-    assert isinstance(emptymeta, dict)
-    assert not emptymeta
-
-    emptymeta = ens.get_smry_meta(["FOPT"])
     assert isinstance(emptymeta, dict)
     assert not emptymeta
 
@@ -473,24 +460,19 @@ def test_ensemble_ecl():
     )
 
     # Summary metadata:
+    reekensemble.load_smry(time_index="yearly", column_keys="*")
     meta = reekensemble.get_smry_meta()
     assert len(meta) == len(reekensemble.get_smrykeys())
     assert "FOPT" in meta
     assert not meta["FOPT"]["is_rate"]
     assert meta["FOPT"]["is_total"]
 
-    meta = reekensemble.get_smry_meta("FOPT")
-    assert meta["FOPT"]["is_total"]
+    # Meta should also be returned via dataframe's "attrs"
+    yearly_df_load = reekensemble.load_smry(time_index="yearly", column_keys="FOPT")
+    assert set(yearly_df_load.attrs["meta"].keys()) == set(["FOPT"])
 
-    meta = reekensemble.get_smry_meta("*")
-    assert meta["FOPT"]["is_total"]
-
-    meta = reekensemble.get_smry_meta(["*"])
-    assert meta["FOPT"]["is_total"]
-
-    meta = reekensemble.get_smry_meta(["FOPT", "BOGUS"])
-    assert meta["FOPT"]["is_total"]
-    assert "BOGUS" not in meta
+    yearly_df_get = reekensemble.get_smry(time_index="yearly", column_keys="FOPT")
+    assert set(yearly_df_get.attrs["meta"].keys()) == set(["FOPT"])
 
     # Eclipse well names list
     assert len(reekensemble.get_wellnames("OP*")) == 5

--- a/tests/test_ensemble_agg.py
+++ b/tests/test_ensemble_agg.py
@@ -39,6 +39,12 @@ def test_ensemble_aggregations(tmpdir):
     }
 
     tmpdir.chdir()
+    assert "FOPT" in stats["min"].get_df("unsmry--yearly").attrs["meta"]
+    assert (
+        "FOPT"
+        in stats["min"].get_smry(column_keys="FOPT", time_index="yearly").attrs["meta"]
+    )
+
     stats["min"].to_disk("virtreal_min", delete=True)
     stats["max"].to_disk("virtreal_max", delete=True)
     stats["mean"].to_disk("virtreal_mean", delete=True)

--- a/tests/test_ensemblecombination.py
+++ b/tests/test_ensemblecombination.py
@@ -52,7 +52,12 @@ def test_ensemblecombination_basic():
         ].sum()
     )
 
-    smrymeta = diff.get_smry_meta(["FO*"])
+    # Test presence of summary metadata:
+    assert "FOPT" in half.get_df("unsmry--yearly").attrs["meta"]
+    assert (
+        "FOPT" in half.get_smry(column_keys="FOPT", time_index="yearly").attrs["meta"]
+    )
+    smrymeta = diff.get_smry_meta()
     assert "FOPT" in smrymeta
 
     # This is only true since we only juggle one ensemble here:
@@ -96,7 +101,7 @@ def test_ensemblecombination_basic():
     # We can test something cheaper:
     zero = reekensemble + reekensemble - 2 * reekensemble
     assert zero["parameters"]["KRW1"].sum() == 0
-    smrymeta = zero.get_smry_meta(["FO*"])
+    smrymeta = zero.get_smry_meta()
     assert "FOPT" in smrymeta
 
     vzero = (
@@ -107,6 +112,7 @@ def test_ensemblecombination_basic():
     assert vzero["parameters"]["KRW1"].sum() == 0
 
     assert len(diff.get_smry(column_keys=["FOPR", "FGPR", "FWCT"]).columns) == 5
+    assert "FOPR" in diff.get_smry(column_keys="FOPR").attrs["meta"]
 
     # eclipse summary vector statistics for a given ensemble
     df_stats = diff.get_smry_stats(column_keys=["FOPR", "FGPR"], time_index="monthly")

--- a/tests/test_realizationcombination.py
+++ b/tests/test_realizationcombination.py
@@ -65,7 +65,9 @@ def test_realizationcombination_basic():
     assert "parameters.txt" not in vdiff_filtered2.keys()
     assert "FWPR" in vdiff_filtered2.get_df("unsmry--yearly")
 
-    smrymeta = realdiff.get_smry_meta(["FO*"])
+    # Summary metadata:
+    assert "FWPR" in vdiff_filtered2.get_df("unsmry--yearly").attrs["meta"]
+    smrymeta = realdiff.get_smry_meta()
     assert "FOPT" in smrymeta
 
     smry_params = realdiff.get_df("unsmry--yearly", merge="parameters.txt")
@@ -93,16 +95,18 @@ def test_realizationcomb_virt_meta():
     real1 = ensemble.ScratchRealization(real1dir)
     real1.load_smry(time_index="yearly", column_keys=["FOPT", "WOPT*"])
 
-    # Virtualized based on the loades summary vectors, which
+    # Virtualized based on the loaded summary vectors, which
     # differ between the two realizations.
     vreal0 = real0.to_virtual()
     vreal1 = real1.to_virtual()
 
-    assert "WOPT" not in vreal0.get_smry_meta(column_keys="*")
-    assert "FOPT" in vreal0.get_smry_meta(column_keys="*")
-    assert "WOPT:OP_3" in vreal1.get_smry_meta(column_keys="*")
-    assert "WOPT:OP_3" not in vreal0.get_smry_meta(column_keys="*")
-    assert "FOPT" in vreal1.get_smry_meta(column_keys="*")
+    assert "FOPT" in vreal0.get_smry(column_keys="FOPT").attrs["meta"]
+
+    assert "WOPT" not in vreal0.get_smry_meta()
+    assert "FOPT" in vreal0.get_smry_meta()
+    assert "WOPT:OP_3" in vreal1.get_smry_meta()
+    assert "WOPT:OP_3" not in vreal0.get_smry_meta()
+    assert "FOPT" in vreal1.get_smry_meta()
 
 
 def test_manual_aggregation():

--- a/tests/test_virtualensemble.py
+++ b/tests/test_virtualensemble.py
@@ -407,10 +407,7 @@ def test_get_smry_meta(tmpdir):
     assert origmeta["FOPT"] == metadict["FOPT"]
     assert origmeta["FWPTH"] == metadict["FWPTH"]
 
-    assert not vens.get_smry_meta([])
-    assert vens.get_smry_meta(column_keys="FOPT")["FOPT"] == origmeta["FOPT"]
-
-    assert not vens.get_smry_meta(column_keys="WOPT:NOTEXISTING")
+    assert vens.get_smry_meta()["FOPT"] == origmeta["FOPT"]
 
     # Test that it is retrievable after dumping to disk:
     vens_disk_path = str(tmpdir.join("vens_dumped"))

--- a/tests/test_virtualrealization.py
+++ b/tests/test_virtualrealization.py
@@ -155,10 +155,10 @@ def test_get_smry():
     assert all(vfopt == fopt)
     # But note that the dtype of the index in each dataframe differs
     # vfopt.index.dtype == datetime, while fopt.index.dtype == object
-    assert len(fopt.columns) == 1  # DATE is index (unlabeled)
+    assert len(fopt.columns) == 2  # DATE is the first column
 
     dvfopt = vreal.get_smry(column_keys="FOPT", time_index="daily")
-    assert all(dvfopt.diff() >= 0)
+    assert all(dvfopt["FOPT"].diff().dropna() >= 0)
     # Linear interpolation should give many unique values:
     assert len(dvfopt["FOPT"].unique()) == 1462
     # Length is here 1462 while daily smry for the scratchrealization
@@ -256,7 +256,7 @@ def test_get_smry2():
 
     alldefaults = vreal.get_smry()
     assert len(alldefaults) == monthly_length
-    assert len(alldefaults.columns) == 49
+    assert len(alldefaults.columns) == 50
 
 
 def test_get_smry_cumulative():

--- a/tests/test_virtualrealization.py
+++ b/tests/test_virtualrealization.py
@@ -129,6 +129,9 @@ def test_virtual_fromdisk(tmpdir):
     )
     assert real.get_df("npv.txt") == 3444
 
+    # Check that metadata for summary has been conserved:
+    assert "FOPT" in vreal.get_df("unsmry--yearly").attrs["meta"]
+
 
 def test_get_smry():
     """Check that we can to get_smry() on virtual realizations"""
@@ -377,6 +380,11 @@ def test_get_smry_meta():
     assert "WOPR:OP_1" in meta
 
     assert meta["FOPT"]["wgname"] is None
+
+    assert "FOPT" in vreal.get_df("unsmry--yearly").attrs["meta"]
+    assert (
+        "FOPT" in vreal.get_smry(column_keys="FOPT", time_index="monthly").attrs["meta"]
+    )
 
 
 def test_get_df_merge():


### PR DESCRIPTION
API CHANGE

* realization.get_smry() returns a dummy index always, with DATE in its own column. This is more in line with the ensemble module.
* cache_eclsum is removed entirely from the API.

Left to do :
* [x] Remove the eclsum concept entirely from realization.py, it should be handled through the EclFiles object
* [ ] Rethink the caching?. Ensure that it is  possible to load thousands of realizations by turning off caching.
* [x] Make changes to ecl2df.summary for what is needed, maybe some of the column key support functions.
* [ ] Does the UNSMRY file discovery make sense when EclFiles is doing the work? Maybe.
* [x] Merge https://github.com/equinor/ecl2df/pull/207 (and publish to pypi) for fmu-ensemble tests to pass in CI
* [x] Get metadata from DataFrame.attrs (via ecl2df).

The 3D grid access functions is also a candidate for refactoring, if the functionality is still needed.