### PR TITLE
Actually display the deprecation warning from etc

### DIFF
--- a/src/fmu/ensemble/etc.py
+++ b/src/fmu/ensemble/etc.py
@@ -9,6 +9,12 @@ import timeit
 
 # pylint: disable=protected-access
 
+warnings.filterwarnings(
+    action="always",
+    category=DeprecationWarning,
+    module=r"etc|ensemble.etc|fmu.ensemble.etc",
+)
+
 
 class _BColors(object):
     # local class for ANSI term color commands


### PR DESCRIPTION
```
(foo) ✔ ~/projects/fmu-ensemble [displaydeprecation L|…7] 
13:32 $ python
Python 3.8.5 (default, Jul 28 2020, 12:59:40) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from fmu import ensemble
>>> ensemble.etc.Interaction()
/home/berland/projects/fmu-ensemble/src/fmu/ensemble/etc.py:42: DeprecationWarning: fmu.ensemble.etc is deprecated and will be removed in later versions.
  warnings.warn(
<fmu.ensemble.etc.Interaction object at 0x7f77b9b9f370>

```