### PR TITLE
Fix tests on komodo deploy

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -1,4 +1,4 @@
-
-install_package () {
-    pip install .[tests,docs]
+install_test_dependencies () {
+  pip install -r test_requirements.txt
+  pip install -r docs_requirements.txt
 }

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,0 +1,5 @@
+ipython
+rstcheck
+sphinx
+sphinx-argparse
+sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -29,28 +29,14 @@ REQUIREMENTS = [
 
 SETUP_REQUIREMENTS = ["setuptools>=28", "setuptools_scm"]
 
-TEST_REQUIREMENTS = [
-    "black>=20.8b0",
-    "flake8>=2.6.0",
-    "pre-commit",
-    "pylint",
-    "pytest>=2.9.2",
-    "pytest-cov",
-    "pyyaml>=5.1",
-]
-
-DOCS_REQUIREMENTS = [
-    "ipython",
-    "rstcheck",
-    "sphinx",
-    "sphinx-argparse",
-    "sphinx_rtd_theme",
-]
-
+with open("test_requirements.txt") as f:
+    test_requirements = f.read().splitlines()
+with open("docs_requirements.txt") as f:
+    docs_requirements = f.read().splitlines()
 
 EXTRAS_REQUIRE = {
-    "tests": TEST_REQUIREMENTS,
-    "docs": DOCS_REQUIREMENTS,
+    "tests": test_requirements,
+    "docs": docs_requirements,
     "parquet": ["pyarrow"],
 }
 
@@ -81,7 +67,7 @@ setup(
         "Programming Language :: Python :: 3.8",
     ],
     test_suite="tests",
-    tests_require=TEST_REQUIREMENTS,
+    tests_require=test_requirements,
     setup_requires=SETUP_REQUIREMENTS,
     extras_require=EXTRAS_REQUIRE,
     python_requires=">=3.6",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,6 @@
+black>=20.8b0
+flake8>=2.6.0
+pylint
+pytest>=2.9.2
+pytest-cov
+pyyaml>=5.1


### PR DESCRIPTION
In order to test installed packages in komodo, we need to install test requirements without installing the package. For that we need to split test requirements into `requirements.txt` files.