### PR TITLE
Bump checkout and setup-python github actions, pin Pandas<2

### DIFF
--- a/.github/workflows/fmu-ensemble.yml
+++ b/.github/workflows/fmu-ensemble.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: 📖 Checkout commit locally
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: 📖 Checkout tags
         # This seems necessary for setuptools_scm to be able to infer
@@ -31,7 +31,7 @@ jobs:
         run: git fetch --unshallow --tags
 
       - name: 🐍 Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("HISTORY.rst", "rb") as history_file:
 REQUIREMENTS = [
     "ecl>=2.9",
     "numpy",
-    "pandas",
+    "pandas<2",
     "pyyaml>=5.1",
 ]
 

--- a/src/fmu/ensemble/etc.py
+++ b/src/fmu/ensemble/etc.py
@@ -294,7 +294,6 @@ class Interaction(object):
         return outer[0]
 
     def _output(self, idx, level, string):
-
         # pylint: disable=too-many-branches
 
         prefix = ""

--- a/src/fmu/ensemble/observations.py
+++ b/src/fmu/ensemble/observations.py
@@ -201,7 +201,6 @@ class Observations(object):
         self.observations["smry"].append(virtobs)
 
     def __len__(self):
-
         """Return the number of observation units present"""
         # This is not correctly implemented yet..
         return len(self.observations.keys())

--- a/src/fmu/ensemble/realization.py
+++ b/src/fmu/ensemble/realization.py
@@ -1128,7 +1128,6 @@ class ScratchRealization(object):
                 parseddate = dateutil.parser.isoparse(time_index)
                 time_index_arg = [parseddate]
             except ValueError:
-
                 time_index_arg = self.get_smry_dates(
                     freq=time_index,
                     start_date=start_date,


### PR DESCRIPTION
Also re-enabled running the actions in the Github web interface as it was deactivated due to 60 days of inactivity.