### PR TITLE
Skip no-commit-to-branch in Github actions

### DIFF
--- a/.github/workflows/fmu-ensemble.yml
+++ b/.github/workflows/fmu-ensemble.yml
@@ -49,6 +49,8 @@ jobs:
         run: pip freeze
 
       - name: 🕵️ Check code style
+        env:
+          SKIP: no-commit-to-branch
         run: |
           pre-commit run --all-files
 


### PR DESCRIPTION
This test is only relevant for human users, not when a Github action is testing the master branch.