### PR TITLE
Catch a possible error in STATUS files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("HISTORY.rst", "rb") as history_file:
 
 REQUIREMENTS = [
     "resdata>=4.0.0",
-    "numpy",
+    "numpy<2",
     "pandas",
     "pyyaml>=5.1",
 ]

--- a/src/fmu/ensemble/realization.py
+++ b/src/fmu/ensemble/realization.py
@@ -571,6 +571,10 @@ class ScratchRealization(object):
                     # We get where if STARTIME.split(':') does not contain
                     # integers only:
                     durations.append(np.nan)
+                except IndexError:
+                    # We get here if a clock time string is invalid, like missing seconds.
+                    print("got indexerror")
+                    durations.append(np.nan)
         status["DURATION"] = durations
 
         # Augment data from jobs.json if that file is available:

--- a/tests/test_realization.py
+++ b/tests/test_realization.py
@@ -235,18 +235,15 @@ def test_status_load(tmpdir):
     assert status["DURATION"].values[0] == 0  # in seconds
     # NB: The current code is not able to pick this error string
 
-    with open(str(tmpdir.join("realization-0/STATUS")), "w") as status_fh:
-        status_fh.write("first line always ignored\n")
-        status_fh.write("INCLUDE_PC                      : 12:XX:55 .... 12:40:55  \n")
-    real = ensemble.ScratchRealization(str(tmpdir.join("realization-0")))
-    status = real.get_df("STATUS")
-    assert len(status) == 1
-    assert "FORWARD_MODEL" in status
-    assert np.isnan(status["DURATION"].values[0])
 
+@pytest.mark.parametrize(
+    "timeinfo", ["12:XX:55 .... 12:40:55", "12:40 .... 12:40:55", "12:40:33 .... 12:41"]
+)
+def test_status_load_wrong_time_syntax(tmpdir, timeinfo: str):
+    tmpdir.join("realization-0").mkdir()
     with open(str(tmpdir.join("realization-0/STATUS")), "w") as status_fh:
         status_fh.write("first line always ignored\n")
-        status_fh.write("INCLUDE_PC                      : 12:40.... 12:40:55  \n")
+        status_fh.write(f"INCLUDE_PC                      :  {timeinfo}   \n")
     real = ensemble.ScratchRealization(str(tmpdir.join("realization-0")))
     status = real.get_df("STATUS")
     assert len(status) == 1


### PR DESCRIPTION
Instead of crashing, we should ignore the line in a garbled STATUS file like we do for other ways it can be garbled.